### PR TITLE
fix web mode for ctd, set cv2.dnn as backend for cpu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ result
 *.ckpt
 *.pt
 .vscode
+*.onnx
 __pycache__
 ocrs

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,3 @@ aiohttp
 tqdm
 sklearn
 deepl
-pandas
-onnxruntime

--- a/textblockdetector/utils/yolov5_utils.py
+++ b/textblockdetector/utils/yolov5_utils.py
@@ -128,6 +128,9 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
     Returns:
          list of detections, on (n,6) tensor per image [xyxy, conf, cls]
     """
+    
+    if isinstance(prediction, np.ndarray):
+        prediction = torch.from_numpy(prediction)
 
     nc = prediction.shape[2] - 5  # number of classes
     xc = prediction[..., 4] > conf_thres  # candidates

--- a/textblockdetector/yolov5/common.py
+++ b/textblockdetector/yolov5/common.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import cv2
 import numpy as np
-import pandas as pd
 import requests
 import torch
 import torch.nn as nn

--- a/translate_demo.py
+++ b/translate_demo.py
@@ -142,7 +142,10 @@ async def infer(
 		print(' -- Translating')
 		update_state(task_id, nonce, 'translating')
 		# in web mode, we can start translation task async
-		requests.post('http://127.0.0.1:5003/request-translation-internal', json = {'task_id': task_id, 'nonce': nonce, 'texts': [r.text for r in text_regions]})
+		if detector == 'ctd':
+			requests.post('http://127.0.0.1:5003/request-translation-internal', json = {'task_id': task_id, 'nonce': nonce, 'texts': [r.get_text() for r in text_regions]})
+		else:
+			requests.post('http://127.0.0.1:5003/request-translation-internal', json = {'task_id': task_id, 'nonce': nonce, 'texts': [r.text for r in text_regions]})
 
 
 

--- a/web_main.py
+++ b/web_main.py
@@ -46,7 +46,7 @@ def convert_img(img) :
 
 @routes.get("/")
 async def index_async(request) :
-	with open('ui.html', 'r') as fp :
+	with open('ui.html', 'r', encoding='utf8') as fp :
 		return web.Response(text=fp.read(), content_type='text/html')
 
 @routes.get("/result/{taskid}")


### PR DESCRIPTION
- Fix web mode for ctd.
- Set cv2.dnn as backend for cpu inference:  4-5 time faster, please download converted onnx file from [here](https://drive.google.com/file/d/1tGNcXijNmYoIydFid1V4H-aL2YPWWQFS/view?usp=sharing). Note the detect_size would be fixed to 1024.   
The new model was badly designed for cpu inference, I'll train a new one after I use it to get cleaner training data ...
