### PR TITLE
fix googletrans mismatch

### DIFF
--- a/translators/__init__.py
+++ b/translators/__init__.py
@@ -164,19 +164,23 @@ async def dispatch(translator: str, src_lang: str, tgt_lang: str, texts: List[st
 		
 	if tgt_lang == 'NONE' or src_lang == 'NONE' :
 		raise Exception
-	TEXTBLK_BREAK = '\n###\n'
+
 	if translator == 'google' :
-		if tgt_lang == 'KOR':
-			concat_texts = '\n'.join(texts)
-		else:
-			concat_texts = TEXTBLK_BREAK.join(texts)
+		concat_texts = '\n'.join(texts)
+		empty_l = 0
+		for txt in texts:
+			if txt == '':
+				empty_l += 1
+			else:
+				break
 		result = await GOOGLE_CLIENT.translate(concat_texts, tgt_lang, src_lang, *args, **kwargs)
 		if not isinstance(result, list):
-			if tgt_lang == 'KOR':
-				result = result.text.split('\n')
-			else:
-				result = result.text.split(TEXTBLK_BREAK.replace('\n', ''))
+			result = empty_l * [''] + result.text.split('\n')
+			empty_r = len(concat_texts) - len(result)
+			if empty_r > 0:
+				result = result + empty_r * ['']
 		result = [text.lstrip().rstrip() for text in result]
+
 	elif translator == 'baidu' :
 		concat_texts = '\n'.join(texts)
 		result = await BAIDU_CLIENT.translate(src_lang, tgt_lang, concat_texts)


### PR DESCRIPTION
google translator automatically strips leading and trailing '\n'.  
``` python
from translators import dispatch as run_translation
import asyncio

async def test():
    text_list = ['', '', 'translation ', '', 'test', '', '']
    translated_sentences = await run_translation('google', 'ENG', 'KOR', text_list)
    print(translated_sentences)
    return

if __name__ == '__main__' :
    import asyncio
    asyncio.run(test())
```

If we concat & split text by '\n', ['', '', 'translation ', '', 'test', '', ''] is given input, output would be ['번역', '', '테스트', '', '', '', ''].  
I tried to use '\n###\n' to concat & split text list, but googletrans turns '###' into '####' bizarrely when the target language is Korean. [#45](https://github.com/zyddnys/manga-image-translator/commit/74713657302a85934a75bb0112c6a873ac2cca8c) seems tried to fix that. ('\n####\n' works  

Another workaround is counting leading/trailing empty text beforehand and appending them afterward, as I did in this pr.

Other translators may have similar behavior (Papago, for example), I didn't do a full test since some of them require keys.