### PR TITLE
A simplistic and naive wordbreak implementation

### DIFF
--- a/text_rendering/text_render.py
+++ b/text_rendering/text_render.py
@@ -412,7 +412,7 @@ def calc_horizontal(font_size: int, rot: int, text: str, limit_width: int) :
 			word_width = 0
 			word_str = ""
 		if line_width + word_width + char_offset_x > limit_width: #force line break mid word
-			if len(word_str) <= 2 or next_is_space: # word is too short or next char would be a space anyway
+			if len(word_str) <= 3 or next_is_space: # word is too short or next char would be a space anyway
 				# clear the current line and start a new one
 				if len(line_str.strip()) > 0: # make sure not to add empty lines
 					line_text_list.append(line_str.strip())

--- a/text_rendering/text_render.py
+++ b/text_rendering/text_render.py
@@ -412,7 +412,7 @@ def calc_horizontal(font_size: int, rot: int, text: str, limit_width: int) :
 			word_width = 0
 			word_str = ""
 		if line_width + word_width + char_offset_x > limit_width: #force line break mid word
-			if len(word_str) <= 3 or next_is_space: # word is too short or next char would be a space anyway
+			if len(word_str) <= 6 or next_is_space: # word is too short or next char would be a space anyway
 				# clear the current line and start a new one
 				if len(line_str.strip()) > 0: # make sure not to add empty lines
 					line_text_list.append(line_str.strip())


### PR DESCRIPTION
Note: I'm not a python developer, so might contain horrible code/not use obvious libs/methods

I gave it a try to add some more logic to the world/line break logic, so it doesn't break off single letters/spaces and uses -.
![grafik](https://user-images.githubusercontent.com/5133936/167301084-71b3221b-76de-4ace-9f6c-17a239c02fcb.png)
becomes
![grafik](https://user-images.githubusercontent.com/5133936/167301033-6a94b916-81b9-4334-9a85-d62a43d9dab4.png)

This is still far from perfect, but an improvement. 
The issues I noticed: 
- it adds line breaks to places like ``I'd``/``don't``, making it ``I-'d``/``don-'t``
- it adds linebreaks where the words would have more than enough space like in the bottom left example, ``pull`` could as well be in the same/next line, shifting everything down a bit.
