### PR TITLE
add missing .ckpt file to colab snippet

### DIFF
--- a/run_as_colab.ipynb
+++ b/run_as_colab.ipynb
@@ -24,6 +24,7 @@
     "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/comictextdetector.pt.onnx\n",
     "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/detect.ckpt\n",
     "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/inpainting.ckpt\n",
+    "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/inpainting_lama_mpe.ckpt\n",
     "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/ocr.ckpt\n",
     "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/ocr-ctc.ckpt"
    ]


### PR DESCRIPTION
I tried to run the [run_as_colab.ipynb](https://github.com/zyddnys/manga-image-translator/blob/main/run_as_colab.ipynb) file, but it said that inpainting_lama_mpe.ckpt was missing. I added it to the wget list.