### PR TITLE
Add Offline translation Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ result
 *.onnx
 __pycache__
 ocrs
+Manga
+Manga-translated

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN apt-get update && \
     apt-get install -y git g++ ffmpeg libsm6 libxext6 && \
     pip install git+https://github.com/lucasb-eyer/pydensecrf.git &&\
-    apt-get remove -y git g++
+    apt-get remove -y g++
 
 # Install pip dependencies
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ VIN: Vietnames
 ### Using CLI
 
 ```bash
-# `--use-cuda` is optional, if you have a compatible NVIDIA GPU, you can use it.
+# `--use-cuda` is optional, if you have a compatible NVIDIA GPU, you can use it. (To GPU accelerate offline translation set the USE_CUDA_FOR_OFFLINE_TRANSLATION env var to true)
 # use `--use-inpainting` to enable inpainting.
 # use `--translator=<translator>` to specify a translator.
 # use `--target-lang=<languge_code>` to specify a target language.
@@ -221,6 +221,9 @@ Or  (For the web server + GPU)
 ```bash
 docker-compose -f demo/doc/docker-compose-web-with-gpu.yml up
 ```
+
+### Docker - Offline translation
+When using offline translation the model is downloaded at runtime into a cache within the container. This cache can be cleared when re-creating the container. In order to avoid this you can create a docker volume and mount it under `/root/.cache/huggingface/`
 
 ### Docker - Building locally
 To build the docker image locally you can run (You will require make on your machine)

--- a/demo/doc/docker-compose-local-dev.yml
+++ b/demo/doc/docker-compose-local-dev.yml
@@ -4,9 +4,9 @@ services:
     build:
       context: ./../../
     container_name: manga_image_translator_localdev
-    command: --verbose --translator=offline --log-web --mode web --manga2eng --use-inpainting --host=0.0.0.0 --port=5003
+    command: --verbose --translator=offline --log-web --mode web --manga2eng --use-inpainting --host=0.0.0.0 --port=5003 # (FOR GPU) --use-cuda
     # Batch Mode
-    #command: --mode=batch --verbose --translator=offline --target-lang=ENG --manga2eng --use-inpainting --image "/app/Manga"
+    #command: --mode=batch --verbose --translator=offline --target-lang=ENG --manga2eng --use-inpainting --image "/app/Manga"# (FOR GPU) --use-cuda
     volumes:
       - ./../../result:/app/result
       - ./../../detection:/app/detection
@@ -23,12 +23,22 @@ services:
       - ./../../ui.html:/app/ui.html
       - facehuggingcache:/root/.cache/huggingface/
 
-      # For Batch Mode
-      #- ./../../Manga:/app/Manga
-      #- ./../../Manga-translated:/app/Manga-translated
+    #  # For Batch Mode
+    #  - ./../../Manga:/app/Manga
+    #  - ./../../Manga-translated:/app/Manga-translated
     ports:
       - 5003:5003
+   
     ipc: host
+
+    # For GPU
+    #environment:
+    #  USE_CUDA_FOR_OFFLINE_TRANSLATION: true
+    #deploy:
+    #  resources:
+    #    reservations:
+    #      devices:
+    #        - capabilities: [gpu]
 
 volumes:
   facehuggingcache:

--- a/demo/doc/docker-compose-local-dev.yml
+++ b/demo/doc/docker-compose-local-dev.yml
@@ -1,0 +1,34 @@
+version: "3.8"
+services:
+  manga_image_translator:
+    build:
+      context: ./../../
+    container_name: manga_image_translator_localdev
+    command: --verbose --translator=offline --log-web --mode web --manga2eng --use-inpainting --host=0.0.0.0 --port=5003
+    # Batch Mode
+    #command: --mode=batch --verbose --translator=offline --target-lang=ENG --manga2eng --use-inpainting --image "/app/Manga"
+    volumes:
+      - ./../../result:/app/result
+      - ./../../detection:/app/detection
+      - ./../../fonts:/app/fonts
+      - ./../../inpainting:/app/inpainting
+      - ./../../ocr:/app/ocr
+      - ./../../text_mask:/app/text_mask
+      - ./../../text_rendering:/app/text_rendering
+      - ./../../translators:/app/translators
+      - ./../../textblockdetector:/app/textblockdetector
+      - ./../../textline_merge:/app/textline_merge
+      - ./../../translate_demo.py:/app/translate_demo.py
+      - ./../../web_main.py:/app/web_main.py
+      - ./../../ui.html:/app/ui.html
+      - facehuggingcache:/root/.cache/huggingface/
+
+      # For Batch Mode
+      #- ./../../Manga:/app/Manga
+      #- ./../../Manga-translated:/app/Manga-translated
+    ports:
+      - 5003:5003
+    ipc: host
+
+volumes:
+  facehuggingcache:

--- a/demo/doc/docker-compose-web-with-gpu.yml
+++ b/demo/doc/docker-compose-web-with-gpu.yml
@@ -6,6 +6,7 @@ services:
     command: --verbose --log-web --mode web --use-inpainting --use-cuda --host=0.0.0.0 --port=5003
     volumes:
       - ./../../translate_demo.py:/app/translate_demo.py
+      - facehuggingcache:/root/.cache/huggingface/
     ports:
       - 5003:5003
     ipc: host
@@ -14,3 +15,6 @@ services:
         reservations:
           devices:
             - capabilities: [gpu]
+
+volumes:
+  facehuggingcache:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ deepl
 ImageHash
 kornia
 backports.cached-property
+huggingface_hub
+transformers
+langdetect

--- a/translate_demo.py
+++ b/translate_demo.py
@@ -8,6 +8,8 @@ import requests
 import os
 from oscrypto import util as crypto_utils
 import asyncio
+import torch
+import huggingface_hub 
 
 from detection import dispatch as dispatch_detection, load_model as load_detection_model
 from ocr import dispatch as dispatch_ocr, load_model as load_ocr_model
@@ -176,13 +178,19 @@ async def infer(
 			translated_sentences = await run_translation(args.translator, 'auto', args.target_lang, [r.text for r in text_regions])
 
 	else :
+		translation_request_timeout = 20
+
 		# wait for at most 1 hour for manual translation
 		if 'manual' in options and options['manual'] :
 			wait_n_10ms = 36000
+		# Wait longer for offline translation given it needs to do some crunching
+		elif 'offline' in args.translator:
+			translation_request_timeout = 60
+			wait_n_10ms = 1200 
 		else :
 			wait_n_10ms = 300 # 30 seconds for machine translation
 		for _ in range(wait_n_10ms) :
-			ret = requests.post(f'http://{args.host}:{args.port}/get-translation-result-internal', json = {'task_id': task_id, 'nonce': nonce}, timeout = 20).json()
+			ret = requests.post(f'http://{args.host}:{args.port}/get-translation-result-internal', json = {'task_id': task_id, 'nonce': nonce}, timeout = translation_request_timeout).json()
 			if 'result' in ret :
 				translated_sentences = ret['result']
 				if isinstance(translated_sentences, str) :
@@ -257,6 +265,15 @@ def replace_prefix(s: str, old: str, new: str) :
 	return s
 
 async def main(mode = 'demo') :
+	print(' -- Preload Checks')
+	# Add failsafe if torch cannot find cuda support
+	if not torch.cuda.is_available():
+		print("Warning: CUDA compatible device could not be found while --use_cuda args was set... Deferring to CPU")
+		args.use_cuda = False
+
+	print(' -- Preload optional models')
+	preload_offline_translator(args.translator)
+
 	print(' -- Loading models')
 	os.makedirs('result', exist_ok = True)
 	text_render.prepare_renderer()
@@ -361,6 +378,30 @@ async def main(mode = 'demo') :
 					import traceback
 					traceback.print_exc()
 					pass
+
+
+def preload_offline_translator(translation_mode):
+	# Use Facebook No Language Left Behind Model to enable offline translation
+	translation_model_map = {
+		"offline": "facebook/nllb-200-distilled-600M",
+		"offline_big": "facebook/nllb-200-distilled-1.3B",
+	}
+
+	if translation_mode in translation_model_map.keys():
+		nllb_model_name = translation_model_map[args.translator]
+		
+
+		# Get if repo exists in cache
+		if not huggingface_hub.try_to_load_from_cache(nllb_model_name, 'pytorch_model.bin') is None:
+			print(f"Detected cached model for offline translation: {nllb_model_name}")
+			return
+		
+		# Preload models into cache as part of startup
+		print(f"Detected offline translation mode. Pre-loading offline translation model: {nllb_model_name} " +
+		       "(This can take a long time as multiple GB's worth of data can be downloaded during this step)")
+		huggingface_hub.snapshot_download(nllb_model_name)
+
+
 
 if __name__ == '__main__':
 	print(args)

--- a/translate_demo.py
+++ b/translate_demo.py
@@ -267,7 +267,7 @@ def replace_prefix(s: str, old: str, new: str) :
 async def main(mode = 'demo') :
 	print(' -- Preload Checks')
 	# Add failsafe if torch cannot find cuda support
-	if not torch.cuda.is_available():
+	if not torch.cuda.is_available() and args.use_cuda:
 		print("Warning: CUDA compatible device could not be found while --use_cuda args was set... Deferring to CPU")
 		args.use_cuda = False
 

--- a/translators/offline.py
+++ b/translators/offline.py
@@ -1,0 +1,99 @@
+from cgitb import reset
+import torch
+import os
+from transformers import AutoTokenizer, AutoModelForSeq2SeqLM, pipeline
+from langdetect import detect
+
+OFFLINE_TRANSLATOR_MODEL_MAP = {
+    "offline": "facebook/nllb-200-distilled-600M",
+    "offline_big": "facebook/nllb-200-distilled-1.3B",
+}
+
+ISO_639_1_TO_FLORES_200 = {
+    'zh-cn': 'zho_Hans',
+	'zh-tw': 'zho_Hant',
+	'ja': 'jpn_Jpan',
+	'en': 'eng_Latn',
+	'kn': 'kor_Hang',
+	'vi': 'vie_Latn',
+	'cs': 'ces_Latn',
+	'nl': 'nld_Latn',
+	'fr': 'fra_Latn',
+	'de': 'deu_Latn',
+	'hu': 'hun_Latn',
+	'it': 'ita_Latn',
+	'pl': 'pol_Latn',
+	'pt': 'por_Latn',
+	'ro': 'ron_Latn',
+	'ru': 'rus_Cyrl',
+	'es': 'spa_Latn',
+	'tr': 'tur_Latn',
+}
+
+class Translator(object):
+    def __init__(self):
+        self.model_name = None
+        self.loaded = False
+        self.model = None
+        self.tokenizer = None
+
+    def load(self, translator):
+        # Lazy load memory heavy models
+        if not self.loaded:
+            self.model_name = OFFLINE_TRANSLATOR_MODEL_MAP[translator]
+            self.model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name)
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            self.loaded = True
+
+    def is_loaded(self):
+        return self.loaded
+
+    async def translate(self, from_lang, to_lang, query_text):
+        if from_lang == 'auto':
+            detected_lang = detect(query_text)
+            target_lang = self._map_detected_lang_to_translator(detected_lang)
+
+            if target_lang == None:
+                print("Warning: Could not detect language from over all scentence. Will try per scentece.")
+            else:
+                from_lang = target_lang
+
+        return [self.translate_sentence(from_lang, to_lang, text) for text in query_text.split('\n')]
+
+    def translate_sentence(self, from_lang, to_lang, query_text) :
+        if not self.is_loaded():
+            return ""
+
+        if from_lang == 'auto':
+            detected_lang = detect(query_text)
+            from_lang = self._map_detected_lang_to_translator(detected_lang)
+
+        if from_lang == None:
+            print(f"Warning: Offline Translation Failed. Could not detect language (Or language not supported for text: {query_text})")
+            return ""
+
+        translator = pipeline('translation', 
+            device=self._get_device(),
+            model=self.model,
+            tokenizer=self.tokenizer,
+            src_lang=from_lang,
+            tgt_lang=to_lang,
+            max_length = 512
+        )
+
+        result = translator(query_text)
+        translated_text = result[0]['translation_text']
+        print(f"Offline Translation[{from_lang} -> {to_lang}] \"{query_text}\" -> \"{translated_text}\"")
+        return translated_text
+
+    def _map_detected_lang_to_translator(self, lang):
+        if not lang in ISO_639_1_TO_FLORES_200.keys():
+            return None
+
+        return ISO_639_1_TO_FLORES_200[lang]
+    
+    @staticmethod
+    def _get_device():
+        # -1: CPU
+        # 0: CUDA DEVICE 0
+        return 0 if torch.cuda.is_available() and os.getenv('USE_CUDA_FOR_OFFLINE_TRANSLATION', False) else -1

--- a/ui.html
+++ b/ui.html
@@ -69,6 +69,7 @@
                   <option value="google">Google</option>
                   <option value="deepl">DeepL</option>
                   <option value="papago">Papago</option>
+                  <option value="offline">Offline</option>
                 </select>
                 <i class="iconify absolute top-1.5 right-1 pointer-events-none" data-icon="carbon:chevron-down"></i>
               </div>

--- a/web_main.py
+++ b/web_main.py
@@ -92,7 +92,7 @@ async def handle_post(request) :
 			direction = 'auto'
 	if 'translator' in data :
 		selected_translator = data['translator'].lower()
-		if selected_translator not in ['youdao', 'baidu', 'google', 'deepl', 'papago', 'null'] :
+		if selected_translator not in ['youdao', 'baidu', 'google', 'deepl', 'papago', 'offline', 'null'] :
 			selected_translator = 'youdao'
 	if 'size' in data :
 		size = data['size'].upper()


### PR DESCRIPTION
# What
This PR adds support for an offline translation mode. (And also adds a local docker stack along side a few other QOL improvements) (Does aim to partially remedy issues found in #41)

# How
This PR relies on the https://ai.facebook.com/research/no-language-left-behind/  model for it's reasonable performance in per sentence language translation and broad support for all currently mapped languages in the tool (In every mapped combination). It supports two modes :

- "offline" which uses the [facebook/nllb-200-distilled-600M](https://huggingface.co/facebook/nllb-200-distilled-600M) model
- "offline_big" which uses the  [facebook/nllb-200-distilled-1.3B](https://huggingface.co/facebook/nllb-200-distilled-1.3B) model

It should be noted that "NLLB-200 is a research model and is not released for production deployment." but in internal testing the translation quality seems acceptable enough to continue for using as a base for a basic offline translation model that can be used to fill any / all language variations. 

More specific models like the one used in Sugoi Translator, http://www.kecl.ntt.co.jp/icl/lirg/jparacrawl/ or https://github.com/argosopentech/argos-translate may offer higher quality translation options but would require a more complex implementation / be significantly less broad in scope.

This has been tested in both CPU (3950x) and GPU (RTX3080) modes and demonstrated reasonable performance in each. With the `big` model loaded GPU ram consumption does not exceed 10GB. (Hovering around 9.5)

The model is automatically downloaded at runtime when "offline" is set for the translation model and then cached.

# Why 
So in theory this could be run standalone without any dependencies on external services. :thinking: 