### PR TITLE
Refactoring of OCR codebase

### DIFF
--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -59,7 +59,6 @@ async def run_default(img: np.ndarray, detect_size: int, cuda: bool, verbose: bo
 	return textlines, np.clip(mask_resized * 255, 0, 255).astype(np.uint8)
 
 async def dispatch(img: np.ndarray, detect_size: int, cuda: bool, args: dict, model_name: str = 'default', verbose: bool = False) -> List[Quadrilateral]:
-	print(' -- Running text detection')
 	if model_name == 'default':
 		global DEFAULT_MODEL
 		if DEFAULT_MODEL is None:

--- a/ocr/__init__.py
+++ b/ocr/__init__.py
@@ -1,257 +1,32 @@
-
-from collections import Counter
-import itertools
-from typing import List, Tuple, Union
-
-from utils import Quadrilateral, quadrilateral_can_merge_region, AvgMeter
-import torch
-import cv2
 import numpy as np
-import einops
-import networkx as nx
+from typing import List
 
-from .model_32px import OCR as OCR_32px
-from .model_48px import OCR as OCR_48px
-from .model_48px_ctc import OCR as OCR_48px_ctc
-from textblockdetector.textblock import TextBlock
+from utils import Quadrilateral
+from .common import CommonOCR, OfflineOCR
+from .ocr import Model32pxOCR, Model48pxCTCOCR
 
-MODEL_32PX = None
-MODEL_48PX = None
-MODEL_48PX_CTC = None
+OCRS = {
+	'32px': Model32pxOCR,
+	'48px_ctc': Model48pxCTCOCR,
+}
+ocr_cache = {}
 
-def load_model(dictionary, cuda: bool, model_name: str = '32px'):
-	global MODEL_32PX, MODEL_48PX, MODEL_48PX_CTC
-	if model_name not in ['32px', '48px', '48px_ctc']:
-		raise Exception
-	if model_name == '32px' and MODEL_32PX is None:
-		model = OCR_32px(dictionary, 768)
-		sd = torch.load('ocr.ckpt', map_location = 'cpu')
-		model.load_state_dict(sd['model'] if 'model' in sd else sd)
-		model.eval()
-		if cuda:
-			model = model.cuda()
-		MODEL_32PX = model
-	elif model_name == '48px' and MODEL_32PX is None:
-		model = OCR_48px(dictionary, 768)
-		sd = torch.load('ocr_48px.ckpt', map_location = 'cpu')
-		model.load_state_dict(sd['model'] if 'model' in sd else sd)
-		model.eval()
-		if cuda:
-			model = model.cuda()
-		MODEL_48PX = model
-	elif model_name == '48px_ctc' and MODEL_48PX_CTC is None:
-		model = OCR_48px_ctc(dictionary, 768)
-		sd = torch.load('ocr-ctc.ckpt', map_location = 'cpu')
-		sd = sd['model'] if 'model' in sd else sd
-		del sd['encoders.layers.0.pe.pe']
-		del sd['encoders.layers.1.pe.pe']
-		del sd['encoders.layers.2.pe.pe']
-		model.load_state_dict(sd, strict = False)
-		model.eval()
-		if cuda:
-			model = model.cuda()
-		MODEL_48PX_CTC = model
+def get_ocr(key: str, *args, **kwargs) -> CommonOCR:
+	if key not in OCRS:
+		raise ValueError(f'Could not find OCR for: "{key}". Choose from the following: %s' % ','.join(OCRS))
+	if not ocr_cache.get(key):
+		ocr = OCRS[key]
+		ocr_cache[key] = ocr(*args, **kwargs)
+	return ocr_cache[key]
 
-def ocr_infer_bacth(img, model, widths):
-	with torch.no_grad():
-		return model.infer_beam_batch(img, widths, beams_k = 5, max_seq_length = 255)
+async def prepare(ocr_key: str, use_cuda: bool):
+	ocr = get_ocr(ocr_key)
+	if isinstance(ocr, OfflineOCR):
+		await ocr.download()
+		await ocr.load('cuda' if use_cuda else 'cpu')
 
-def chunks(lst, n):
-	"""Yield successive n-sized chunks from lst."""
-	for i in range(0, len(lst), n):
-		yield lst[i:i + n]
-
-def run_ocr_32px(img: np.ndarray, cuda: bool, quadrilaterals: List[Tuple[Union[Quadrilateral, TextBlock], str]], max_chunk_size = 16, verbose: bool = False):
-	text_height = 32
-	regions = [q.get_transformed_region(img, d, text_height) for q, d in quadrilaterals]
-	out_regions = []
-
-	perm = range(len(regions))
-	if len(quadrilaterals) > 0: 
-		if isinstance(quadrilaterals[0][0], Quadrilateral):
-			perm = sorted(range(len(regions)), key = lambda x: regions[x].shape[1])
-
-	ix = 0
-	for indices in chunks(perm, max_chunk_size):
-		N = len(indices)
-		widths = [regions[i].shape[1] for i in indices]
-		max_width = 4 * (max(widths) + 7) // 4
-		region = np.zeros((N, text_height, max_width, 3), dtype = np.uint8)
-		for i, idx in enumerate(indices):
-			W = regions[idx].shape[1]
-			region[i, :, : W, :] = regions[idx]
-			if verbose:
-				if quadrilaterals[idx][1] == 'v':
-					cv2.imwrite(f'ocrs/{ix}.png', cv2.rotate(cv2.cvtColor(region[i, :, :, :], cv2.COLOR_RGB2BGR), cv2.ROTATE_90_CLOCKWISE))
-				else:
-					cv2.imwrite(f'ocrs/{ix}.png', cv2.cvtColor(region[i, :, :, :], cv2.COLOR_RGB2BGR))
-			ix += 1
-		images = (torch.from_numpy(region).float() - 127.5) / 127.5
-		images = einops.rearrange(images, 'N H W C -> N C H W')
-		if cuda:
-			images = images.cuda()
-		ret = ocr_infer_bacth(images, MODEL_32PX, widths)
-		for i, (pred_chars_index, prob, fr, fg, fb, br, bg, bb) in enumerate(ret):
-			if prob < 0.7:
-				continue
-			fr = (torch.clip(fr.view(-1), 0, 1).mean() * 255).long().item()
-			fg = (torch.clip(fg.view(-1), 0, 1).mean() * 255).long().item()
-			fb = (torch.clip(fb.view(-1), 0, 1).mean() * 255).long().item()
-			br = (torch.clip(br.view(-1), 0, 1).mean() * 255).long().item()
-			bg = (torch.clip(bg.view(-1), 0, 1).mean() * 255).long().item()
-			bb = (torch.clip(bb.view(-1), 0, 1).mean() * 255).long().item()
-			seq = []
-			for chid in pred_chars_index:
-				ch = MODEL_32PX.dictionary[chid]
-				if ch == '<S>':
-					continue
-				if ch == '</S>':
-					break
-				if ch == '<SP>':
-					ch = ' '
-				seq.append(ch)
-			txt = ''.join(seq)
-			print(prob, txt, f'fg: ({fr}, {fg}, {fb})', f'bg: ({br}, {bg}, {bb})')
-			cur_region = quadrilaterals[indices[i]][0]
-			if isinstance(cur_region, Quadrilateral):
-				cur_region.text = txt
-				cur_region.prob = prob
-				cur_region.fg_r = fr
-				cur_region.fg_g = fg
-				cur_region.fg_b = fb
-				cur_region.bg_r = br
-				cur_region.bg_g = bg
-				cur_region.bg_b = bb
-			else:
-				cur_region.text.append(txt)
-				cur_region.fg_r += fr
-				cur_region.fg_g += fg
-				cur_region.fg_b += fb
-				cur_region.bg_r += br
-				cur_region.bg_g += bg
-				cur_region.bg_b += bb
-
-			out_regions.append(cur_region)
-	return out_regions
-
-def run_ocr_48px_ctc(img: np.ndarray, cuda: bool, quadrilaterals: List[Tuple[Union[Quadrilateral, TextBlock], str]], max_chunk_size = 16, verbose: bool = False):
-	text_height = 48
-	regions = [q.get_transformed_region(img, d, text_height) for q, d in quadrilaterals]
-	out_regions = []
-
-	perm = range(len(regions))
-	if len(quadrilaterals) > 0: 
-		if isinstance(quadrilaterals[0][0], Quadrilateral):
-			perm = sorted(range(len(regions)), key = lambda x: regions[x].shape[1])
-
-	ix = 0
-	for indices in chunks(perm, max_chunk_size):
-		N = len(indices)
-		widths = [regions[i].shape[1] for i in indices]
-		max_width = (4 * (max(widths) + 7) // 4) + 128
-		region = np.zeros((N, text_height, max_width, 3), dtype = np.uint8)
-		for i, idx in enumerate(indices):
-			W = regions[idx].shape[1]
-			region[i, :, : W, :] = regions[idx]
-			if verbose:
-				if quadrilaterals[idx][1] == 'v':
-					cv2.imwrite(f'ocrs/{ix}.png', cv2.rotate(cv2.cvtColor(region[i, :, :, :], cv2.COLOR_RGB2BGR), cv2.ROTATE_90_CLOCKWISE))
-				else:
-					cv2.imwrite(f'ocrs/{ix}.png', cv2.cvtColor(region[i, :, :, :], cv2.COLOR_RGB2BGR))
-			ix += 1
-		images = (torch.from_numpy(region).float() - 127.5) / 127.5
-		images = einops.rearrange(images, 'N H W C -> N C H W')
-		if cuda:
-			images = images.cuda()
-		with torch.inference_mode():
-			texts = MODEL_48PX_CTC.decode(images, widths, 0, verbose = verbose)
-		for i, single_line in enumerate(texts):
-			if not single_line:
-				continue
-			cur_texts = []
-			total_fr = AvgMeter()
-			total_fg = AvgMeter()
-			total_fb = AvgMeter()
-			total_br = AvgMeter()
-			total_bg = AvgMeter()
-			total_bb = AvgMeter()
-			total_logprob = AvgMeter()
-			for (chid, logprob, fr, fg, fb, br, bg, bb) in single_line:
-				ch = MODEL_48PX_CTC.dictionary[chid]
-				if ch == '<SP>':
-					ch = ' '
-				cur_texts.append(ch)
-				total_logprob(logprob)
-				if ch != ' ':
-					total_fr(int(fr * 255))
-					total_fg(int(fg * 255))
-					total_fb(int(fb * 255))
-					total_br(int(br * 255))
-					total_bg(int(bg * 255))
-					total_bb(int(bb * 255))
-			prob = np.exp(total_logprob())
-			if prob < 0.3:
-				continue
-			txt = ''.join(cur_texts)
-			fr = int(total_fr())
-			fg = int(total_fg())
-			fb = int(total_fb())
-			br = int(total_br())
-			bg = int(total_bg())
-			bb = int(total_bb())
-			print(prob, txt, f'fg: ({fr}, {fg}, {fb})', f'bg: ({br}, {bg}, {bb})')
-			cur_region = quadrilaterals[indices[i]][0]
-			if isinstance(cur_region, Quadrilateral):
-				cur_region.text = txt
-				cur_region.prob = prob
-				cur_region.fg_r = fr
-				cur_region.fg_g = fg
-				cur_region.fg_b = fb
-				cur_region.bg_r = br
-				cur_region.bg_g = bg
-				cur_region.bg_b = bb
-			else:
-				cur_region.text.append(txt)
-				cur_region.fg_r += fr
-				cur_region.fg_g += fg
-				cur_region.fg_b += fb
-				cur_region.bg_r += br
-				cur_region.bg_g += bg
-				cur_region.bg_b += bb
-			out_regions.append(cur_region)
-	return out_regions
-
-def generate_text_direction(bboxes: List[Union[Quadrilateral, TextBlock]]):
-	if len(bboxes) > 0:
-		if isinstance(bboxes[0], TextBlock):
-			for blk in bboxes:
-				majority_dir = 'v' if blk.vertical else 'h'
-				for line_idx in range(len(blk.lines)):
-					yield blk, line_idx
-		else:
-			G = nx.Graph()
-			for i, box in enumerate(bboxes):
-				G.add_node(i, box = box)
-			for ((u, ubox), (v, vbox)) in itertools.combinations(enumerate(bboxes), 2):
-				if quadrilateral_can_merge_region(ubox, vbox):
-					G.add_edge(u, v)
-			for node_set in nx.algorithms.components.connected_components(G):
-				nodes = list(node_set)
-				# majority vote for direction
-				dirs = [box.direction for box in [bboxes[i] for i in nodes]]
-				majority_dir = Counter(dirs).most_common(1)[0][0]
-				# sort
-				if majority_dir == 'h':
-					nodes = sorted(nodes, key = lambda x: bboxes[x].aabb.y + bboxes[x].aabb.h // 2)
-				elif majority_dir == 'v':
-					nodes = sorted(nodes, key = lambda x: -(bboxes[x].aabb.x + bboxes[x].aabb.w))
-				# yield overall bbox and sorted indices
-				for node in nodes:
-					yield bboxes[node], majority_dir
-
-async def dispatch(img: np.ndarray, textlines: List[Union[Quadrilateral, TextBlock]], cuda: bool, args: dict, model_name: str = '32px', batch_size: int = 16, verbose: bool = False) -> List[Quadrilateral]:
-	print(' -- Running OCR')
-	if model_name == '32px':
-		return run_ocr_32px(img, cuda, list(generate_text_direction(textlines)), batch_size, verbose = verbose)
-	elif model_name == '48px_ctc':
-		return run_ocr_48px_ctc(img, cuda, list(generate_text_direction(textlines)), batch_size, verbose = verbose)
+async def dispatch(ocr_key: str, image: np.ndarray, textlines: List[Quadrilateral], use_cuda: bool = False, verbose: bool = False) -> List[Quadrilateral]:
+	ocr = get_ocr(ocr_key)
+	if isinstance(ocr, OfflineOCR):
+		await ocr.load('cuda' if use_cuda else 'cpu')
+	return await ocr.recognize(image, textlines, verbose)

--- a/ocr/common.py
+++ b/ocr/common.py
@@ -1,0 +1,29 @@
+import os
+import numpy as np
+from abc import ABC, abstractmethod
+from typing import List
+
+from utils import ModelWrapper, Quadrilateral
+
+class CommonOCR(ABC):
+
+    async def recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
+        '''
+        Performs the optical character recognition, using the `textlines` as areas of interests.
+        Returns quadrilaterals defined by the `textlines` which contain the recognized text.
+        '''
+        return await self._recognize(image, textlines, verbose)
+
+    @abstractmethod
+    async def _recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
+        pass
+
+class OfflineOCR(CommonOCR, ModelWrapper):
+    _MODEL_DIR = os.path.join(ModelWrapper._MODEL_DIR, 'ocr')
+
+    async def _recognize(self, *args, **kwargs):
+        return await self.forward(*args, **kwargs)
+
+    @abstractmethod
+    async def _forward(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
+        pass

--- a/ocr/model_32px.py
+++ b/ocr/model_32px.py
@@ -1,14 +1,10 @@
-
+import math
+from typing import List
 from collections import defaultdict
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-import heapq
-import math
-import einops
-
-from typing import List, Tuple, Optional
 
 class ResNet(nn.Module):
 

--- a/ocr/model_48px.py
+++ b/ocr/model_48px.py
@@ -1,14 +1,10 @@
-
+import math
+from typing import List
 from collections import defaultdict
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-import heapq
-import math
-import einops
-
-from typing import List, Tuple, Optional
 
 class ResNet(nn.Module):
 

--- a/ocr/model_48px_ctc.py
+++ b/ocr/model_48px_ctc.py
@@ -1,14 +1,9 @@
+import math
+from typing import List, Tuple, Optional
 
-from collections import defaultdict
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-import heapq
-import math
-import einops
-
-from typing import List, Tuple, Optional
 
 class PositionalEncoding(nn.Module):
 	def __init__(self, d_model, dropout=0.1, max_len=5000):

--- a/ocr/model_ocr_large.py
+++ b/ocr/model_ocr_large.py
@@ -1,14 +1,10 @@
-
+import math
+from typing import List
 from collections import defaultdict
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-import heapq
-import math
-import einops
-
-from typing import List, Tuple, Optional
 
 class ResNet(nn.Module):
 

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -1,0 +1,270 @@
+import os
+from typing import List
+from collections import Counter
+import networkx as nx
+import cv2
+import torch
+import numpy as np
+import einops
+import itertools
+
+from .common import OfflineOCR
+from .model_32px import OCR as OCR_32px
+from .model_48px_ctc import OCR as OCR_48px_ctc
+from utils import Quadrilateral, AvgMeter
+from textblockdetector.textblock import TextBlock
+
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+def generate_text_direction(bboxes: List[Quadrilateral]):
+    if len(bboxes) > 0:
+        if isinstance(bboxes[0], TextBlock):
+            for blk in bboxes:
+                majority_dir = 'v' if blk.vertical else 'h'
+                for line_idx in range(len(blk.lines)):
+                    yield blk, line_idx
+        else:
+            from utils import quadrilateral_can_merge_region
+
+            G = nx.Graph()
+            for i, box in enumerate(bboxes):
+                G.add_node(i, box = box)
+            for ((u, ubox), (v, vbox)) in itertools.combinations(enumerate(bboxes), 2):
+                if quadrilateral_can_merge_region(ubox, vbox):
+                    G.add_edge(u, v)
+            for node_set in nx.algorithms.components.connected_components(G):
+                nodes = list(node_set)
+                # majority vote for direction
+                dirs = [box.direction for box in [bboxes[i] for i in nodes]]
+                majority_dir = Counter(dirs).most_common(1)[0][0]
+                # sort
+                if majority_dir == 'h':
+                    nodes = sorted(nodes, key = lambda x: bboxes[x].aabb.y + bboxes[x].aabb.h // 2)
+                elif majority_dir == 'v':
+                    nodes = sorted(nodes, key = lambda x: -(bboxes[x].aabb.x + bboxes[x].aabb.w))
+                # yield overall bbox and sorted indices
+                for node in nodes:
+                    yield bboxes[node], majority_dir
+
+class Model32pxOCR(OfflineOCR):
+    _MODEL_MAPPING = {
+        'model': {
+            'url': 'https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/ocr.ckpt',
+            'hash': 'D9F619A9DCCCE8CE88357D1B17D25F07806F225C033EA42C64E86C45446CFE71',
+            'file': '.',
+        },
+    }
+
+    async def _load(self, device: str):
+        with open('alphabet-all-v5.txt', 'r', encoding = 'utf-8') as fp:
+            dictionary = [s[:-1] for s in fp.readlines()]
+
+        self.model = OCR_32px(dictionary, 768)
+        sd = torch.load(self._get_file_path('ocr.ckpt'), map_location = 'cpu')
+        self.model.load_state_dict(sd['model'] if 'model' in sd else sd)
+        self.model.eval()
+        self.use_cuda = device == 'cuda'
+        if self.use_cuda:
+            self.model = self.model.cuda()
+
+    async def _unload(self):
+        del self.model
+    
+    async def _forward(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
+        text_height = 32
+        max_chunk_size = 16
+
+        quadrilaterals = list(generate_text_direction(textlines))
+        regions = [q.get_transformed_region(image, d, text_height) for q, d in quadrilaterals]
+        out_regions = []
+
+        perm = range(len(regions))
+        if len(quadrilaterals) > 0 and isinstance(quadrilaterals[0][0], Quadrilateral):
+            perm = sorted(range(len(regions)), key = lambda x: regions[x].shape[1])
+
+        ix = 0
+        for indices in chunks(perm, max_chunk_size):
+            N = len(indices)
+            widths = [regions[i].shape[1] for i in indices]
+            max_width = 4 * (max(widths) + 7) // 4
+            region = np.zeros((N, text_height, max_width, 3), dtype = np.uint8)
+            for i, idx in enumerate(indices):
+                W = regions[idx].shape[1]
+                region[i, :, : W, :] = regions[idx]
+                if verbose:
+                    os.makedirs('result/ocrs/', exist_ok=True)
+                    if quadrilaterals[idx][1] == 'v':
+                        cv2.imwrite(f'result/ocrs/{ix}.png', cv2.rotate(cv2.cvtColor(region[i, :, :, :], cv2.COLOR_RGB2BGR), cv2.ROTATE_90_CLOCKWISE))
+                    else:
+                        cv2.imwrite(f'result/ocrs/{ix}.png', cv2.cvtColor(region[i, :, :, :], cv2.COLOR_RGB2BGR))
+                ix += 1
+            image_tensor = (torch.from_numpy(region).float() - 127.5) / 127.5
+            image_tensor = einops.rearrange(image_tensor, 'N H W C -> N C H W')
+            if self.use_cuda:
+                image_tensor = image_tensor.cuda()
+            with torch.no_grad():
+                ret = self.model.infer_beam_batch(image_tensor, widths, beams_k = 5, max_seq_length = 255)
+            for i, (pred_chars_index, prob, fr, fg, fb, br, bg, bb) in enumerate(ret):
+                if prob < 0.7:
+                    continue
+                fr = (torch.clip(fr.view(-1), 0, 1).mean() * 255).long().item()
+                fg = (torch.clip(fg.view(-1), 0, 1).mean() * 255).long().item()
+                fb = (torch.clip(fb.view(-1), 0, 1).mean() * 255).long().item()
+                br = (torch.clip(br.view(-1), 0, 1).mean() * 255).long().item()
+                bg = (torch.clip(bg.view(-1), 0, 1).mean() * 255).long().item()
+                bb = (torch.clip(bb.view(-1), 0, 1).mean() * 255).long().item()
+                seq = []
+                for chid in pred_chars_index:
+                    ch = self.model.dictionary[chid]
+                    if ch == '<S>':
+                        continue
+                    if ch == '</S>':
+                        break
+                    if ch == '<SP>':
+                        ch = ' '
+                    seq.append(ch)
+                txt = ''.join(seq)
+                print(prob, txt, f'fg: ({fr}, {fg}, {fb})', f'bg: ({br}, {bg}, {bb})')
+                cur_region = quadrilaterals[indices[i]][0]
+                if isinstance(cur_region, Quadrilateral):
+                    cur_region.text = txt
+                    cur_region.prob = prob
+                    cur_region.fg_r = fr
+                    cur_region.fg_g = fg
+                    cur_region.fg_b = fb
+                    cur_region.bg_r = br
+                    cur_region.bg_g = bg
+                    cur_region.bg_b = bb
+                else:
+                    cur_region.text.append(txt)
+                    cur_region.fg_r += fr
+                    cur_region.fg_g += fg
+                    cur_region.fg_b += fb
+                    cur_region.bg_r += br
+                    cur_region.bg_g += bg
+                    cur_region.bg_b += bb
+
+                out_regions.append(cur_region)
+        return out_regions
+
+class Model48pxCTCOCR(OfflineOCR):
+    _MODEL_MAPPING = {
+        'model': {
+            'url': 'https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/ocr-ctc.ckpt',
+            'hash': '8B0837A24DA5FDE96C23CA47BB7ABD590CD5B185C307E348C6E0B7238178ED89',
+            'file': '.',
+        },
+    }
+
+    async def _load(self, device: str):
+        with open('alphabet-all-v5.txt', 'r', encoding = 'utf-8') as fp:
+            dictionary = [s[:-1] for s in fp.readlines()]
+
+        self.model = OCR_48px_ctc(dictionary, 768)
+        sd = torch.load(self._get_file_path('ocr-ctc.ckpt'), map_location = 'cpu')
+        sd = sd['model'] if 'model' in sd else sd
+        del sd['encoders.layers.0.pe.pe']
+        del sd['encoders.layers.1.pe.pe']
+        del sd['encoders.layers.2.pe.pe']
+        self.model.load_state_dict(sd, strict = False)
+        self.model.eval()
+        self.use_cuda = device == 'cuda'
+        if self.use_cuda:
+            self.model = self.model.cuda()
+    
+    async def _unload(self):
+        del self.model
+
+    async def _forward(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
+        text_height = 48
+        max_chunk_size = 16
+
+        quadrilaterals = list(generate_text_direction(textlines))
+        regions = [q.get_transformed_region(image, d, text_height) for q, d in quadrilaterals]
+        out_regions = []
+
+        perm = range(len(regions))
+        if len(quadrilaterals) > 0:
+            if isinstance(quadrilaterals[0][0], Quadrilateral):
+                perm = sorted(range(len(regions)), key = lambda x: regions[x].shape[1])
+
+        ix = 0
+        for indices in chunks(perm, max_chunk_size):
+            N = len(indices)
+            widths = [regions[i].shape[1] for i in indices]
+            max_width = (4 * (max(widths) + 7) // 4) + 128
+            region = np.zeros((N, text_height, max_width, 3), dtype = np.uint8)
+            for i, idx in enumerate(indices):
+                W = regions[idx].shape[1]
+                region[i, :, : W, :] = regions[idx]
+                if verbose:
+                    os.makedirs('result/ocrs/', exist_ok=True)
+                    if quadrilaterals[idx][1] == 'v':
+                        cv2.imwrite(f'result/ocrs/{ix}.png', cv2.rotate(cv2.cvtColor(region[i, :, :, :], cv2.COLOR_RGB2BGR), cv2.ROTATE_90_CLOCKWISE))
+                    else:
+                        cv2.imwrite(f'result/ocrs/{ix}.png', cv2.cvtColor(region[i, :, :, :], cv2.COLOR_RGB2BGR))
+                ix += 1
+            images = (torch.from_numpy(region).float() - 127.5) / 127.5
+            images = einops.rearrange(images, 'N H W C -> N C H W')
+            if self.use_cuda:
+                images = images.cuda()
+            with torch.inference_mode():
+                texts = self.model.decode(images, widths, 0, verbose = verbose)
+            for i, single_line in enumerate(texts):
+                if not single_line:
+                    continue
+                cur_texts = []
+                total_fr = AvgMeter()
+                total_fg = AvgMeter()
+                total_fb = AvgMeter()
+                total_br = AvgMeter()
+                total_bg = AvgMeter()
+                total_bb = AvgMeter()
+                total_logprob = AvgMeter()
+                for (chid, logprob, fr, fg, fb, br, bg, bb) in single_line:
+                    ch = self.model.dictionary[chid]
+                    if ch == '<SP>':
+                        ch = ' '
+                    cur_texts.append(ch)
+                    total_logprob(logprob)
+                    if ch != ' ':
+                        total_fr(int(fr * 255))
+                        total_fg(int(fg * 255))
+                        total_fb(int(fb * 255))
+                        total_br(int(br * 255))
+                        total_bg(int(bg * 255))
+                        total_bb(int(bb * 255))
+                prob = np.exp(total_logprob())
+                if prob < 0.3:
+                    continue
+                txt = ''.join(cur_texts)
+                fr = int(total_fr())
+                fg = int(total_fg())
+                fb = int(total_fb())
+                br = int(total_br())
+                bg = int(total_bg())
+                bb = int(total_bb())
+                print(prob, txt, f'fg: ({fr}, {fg}, {fb})', f'bg: ({br}, {bg}, {bb})')
+                cur_region = quadrilaterals[indices[i]][0]
+                if isinstance(cur_region, Quadrilateral):
+                    cur_region.text = txt
+                    cur_region.prob = prob
+                    cur_region.fg_r = fr
+                    cur_region.fg_g = fg
+                    cur_region.fg_b = fb
+                    cur_region.bg_r = br
+                    cur_region.bg_g = bg
+                    cur_region.bg_b = bb
+                else:
+                    cur_region.text.append(txt)
+                    cur_region.fg_r += fr
+                    cur_region.fg_g += fg
+                    cur_region.fg_b += fb
+                    cur_region.bg_r += br
+                    cur_region.bg_g += bg
+                    cur_region.bg_b += bb
+                out_regions.append(cur_region)
+        return out_regions

--- a/ocr/ocr.py
+++ b/ocr/ocr.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from typing import List
 from collections import Counter
 import networkx as nx
@@ -57,6 +58,11 @@ class Model32pxOCR(OfflineOCR):
             'file': '.',
         },
     }
+
+    def __init__(self):
+        if os.path.exists('ocr.ckpt'):
+            shutil.move('ocr.ckpt', self._get_file_path('ocr.ckpt'))
+        super().__init__()
 
     async def _load(self, device: str):
         with open('alphabet-all-v5.txt', 'r', encoding = 'utf-8') as fp:
@@ -158,6 +164,11 @@ class Model48pxCTCOCR(OfflineOCR):
             'file': '.',
         },
     }
+
+    def __init__(self):
+        if os.path.exists('ocr-ctc.ckpt'):
+            shutil.move('ocr-ctc.ckpt', self._get_file_path('ocr-ctc.ckpt'))
+        super().__init__()
 
     async def _load(self, device: str):
         with open('alphabet-all-v5.txt', 'r', encoding = 'utf-8') as fp:

--- a/run_as_colab.ipynb
+++ b/run_as_colab.ipynb
@@ -24,9 +24,7 @@
     "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/comictextdetector.pt.onnx\n",
     "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/detect.ckpt\n",
     "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/inpainting.ckpt\n",
-    "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/inpainting_lama_mpe.ckpt\n",
-    "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/ocr.ckpt\n",
-    "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/ocr-ctc.ckpt"
+    "!wget https://github.com/zyddnys/manga-image-translator/releases/download/beta-0.3/inpainting_lama_mpe.ckpt"
    ]
   },
   {

--- a/translators/__init__.py
+++ b/translators/__init__.py
@@ -8,7 +8,7 @@ from .youdao import YoudaoTranslator
 from .deepl import DeeplTranslator
 from .papago import PapagoTranslator
 from .nnlb import NNLBTranslator, NNLBBigTranslator
-from .jparacrawl import JParaCrawlTranslator, JParaCrawlSmallTranslator, JParaCrawlBigTranslator
+from .sugoi import SugoiTranslator, SugoiSmallTranslator, SugoiBigTranslator
 from .selective import SelectiveOfflineTranslator, SelectiveBigOfflineTranslator, prepare as prepare_selective_translator
 from .none import NoneTranslator
 
@@ -39,9 +39,9 @@ OFFLINE_TRANSLATORS = {
 	'offline_big': SelectiveBigOfflineTranslator,
 	'nnlb': NNLBTranslator,
 	'nnlb_big': NNLBBigTranslator,
-	'sugoi': JParaCrawlTranslator,
-	'sugoi_small': JParaCrawlSmallTranslator,
-	'sugoi_big': JParaCrawlBigTranslator,
+	'sugoi': SugoiTranslator,
+	'sugoi_small': SugoiSmallTranslator,
+	'sugoi_big': SugoiBigTranslator,
 }
 
 TRANSLATORS = {

--- a/translators/__init__.py
+++ b/translators/__init__.py
@@ -71,7 +71,7 @@ async def prepare(translator_key: str, src_lang: str, tgt_lang: str):
 	if isinstance(translator, OfflineTranslator):
 		await translator.download()
 
-async def dispatch(translator_key: str, src_lang: str, tgt_lang: str, queries: List[str], **kwargs) -> List[str]:
+async def dispatch(translator_key: str, src_lang: str, tgt_lang: str, queries: List[str], use_cuda: bool = False) -> List[str]:
 	if not queries:
 		return queries
 
@@ -84,7 +84,7 @@ async def dispatch(translator_key: str, src_lang: str, tgt_lang: str, queries: L
 
 	if isinstance(translator, OfflineTranslator):
 		if not translator.is_loaded():
-			device = 'cuda' if kwargs.get('use_cuda', False) else 'cpu'
+			device = 'cuda' if use_cuda else 'cpu'
 			await translator.load(src_lang, tgt_lang, device)
 		result = await asyncio.create_task(translator.translate(src_lang, tgt_lang, queries))
 	else:

--- a/translators/__init__.py
+++ b/translators/__init__.py
@@ -10,7 +10,7 @@ from .papago import PapagoTranslator
 from .nnlb import NNLBTranslator, NNLBBigTranslator
 from .jparacrawl import JParaCrawlTranslator, JParaCrawlSmallTranslator, JParaCrawlBigTranslator
 from .selective import SelectiveOfflineTranslator, SelectiveBigOfflineTranslator, prepare as prepare_selective_translator
-from .none import NoTranslator
+from .none import NoneTranslator
 
 VALID_LANGUAGES = {
 	'CHS': 'Chinese (Simplified)',
@@ -50,7 +50,7 @@ TRANSLATORS = {
 	'baidu': BaiduTranslator,
 	'deepl': DeeplTranslator,
 	'papago': PapagoTranslator,
-	'none': NoTranslator,
+	'none': NoneTranslator,
 	**OFFLINE_TRANSLATORS,
 }
 translator_cache = {}
@@ -72,8 +72,6 @@ async def prepare(translator_key: str, src_lang: str, tgt_lang: str):
 		await translator.download()
 
 async def dispatch(translator_key: str, src_lang: str, tgt_lang: str, queries: List[str], **kwargs) -> List[str]:
-	if translator_key == 'null':
-		return queries
 	if not queries:
 		return queries
 

--- a/translators/common.py
+++ b/translators/common.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from typing import List, Tuple
 from abc import abstractmethod
 import os
@@ -15,22 +14,17 @@ class LanguageUnsupportedException(Exception):
 class CommonTranslator():
     _LANGUAGE_CODE_MAP = {}
 
-    @cached_property
-    def supported_src_languages(self) -> List[str]:
-        return ['auto'] + list(self._LANGUAGE_CODE_MAP)
+    def supports_languages(self, from_lang: str, to_lang: str, fatal: bool = False) -> bool:
+        supported_src_languages = ['auto'] + list(self._LANGUAGE_CODE_MAP)
+        supported_tgt_languages = list(self._LANGUAGE_CODE_MAP)
 
-    @cached_property
-    def supported_tgt_languages(self) -> List[str]:
-        return list(self._LANGUAGE_CODE_MAP)
-
-    def supports_languages(self, from_lang: str, to_lang: str, fatal: bool = False):
-        if from_lang not in self.supported_src_languages:
+        if from_lang not in supported_src_languages:
             if fatal:
-                raise LanguageUnsupportedException(from_lang, self.__class__.__name__, self.supported_src_languages)
+                raise LanguageUnsupportedException(from_lang, self.__class__.__name__, supported_src_languages)
             return False
-        if to_lang not in self.supported_tgt_languages:
+        if to_lang not in supported_tgt_languages:
             if fatal:
-                raise LanguageUnsupportedException(to_lang, self.__class__.__name__, self.supported_tgt_languages)
+                raise LanguageUnsupportedException(to_lang, self.__class__.__name__, supported_tgt_languages)
             return False
         return True
 

--- a/translators/common.py
+++ b/translators/common.py
@@ -1,17 +1,17 @@
 from typing import List, Tuple
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 import os
 
 from utils import ModelWrapper
 
 class LanguageUnsupportedException(Exception):
-    def __init__(self, language_code: str, translator: str = None, supported_languages: List[str] = None, *args: object) -> None:
+    def __init__(self, language_code: str, translator: str = None, supported_languages: List[str] = None) -> None:
         error = 'Language not supported for %s: "%s"' % (translator if translator else 'chosen translator', language_code)
         if supported_languages:
             error += '. Supported languages: "%s"' % ','.join(supported_languages)
-        super().__init__(error, *args)
+        super().__init__(error)
 
-class CommonTranslator():
+class CommonTranslator(ABC):
     _LANGUAGE_CODE_MAP = {}
 
     def supports_languages(self, from_lang: str, to_lang: str, fatal: bool = False) -> bool:
@@ -51,8 +51,8 @@ class CommonTranslator():
 class OfflineTranslator(CommonTranslator, ModelWrapper):
     _MODEL_DIR = os.path.join(ModelWrapper._MODEL_DIR, 'translators')
 
-    async def _translate(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:
-        return await self.forward(from_lang, to_lang, queries)
+    async def _translate(self, *args, **kwargs):
+        return await self.forward(*args, **kwargs)
 
     @abstractmethod
     async def _forward(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:

--- a/translators/none.py
+++ b/translators/none.py
@@ -1,24 +1,11 @@
+from typing import List
+
 from translators.common import CommonTranslator
-class NoTranslator(CommonTranslator):
-	_LANGUAGE_CODE_MAP = {
-		'CHS': 0,
-		'CHT': 0,
-		'JPN': 0,
-		'KOR': 0,
-		'ENG': 0,
-		'CSY': 0,
-		'NLD': 0,
-		'FRA': 0,
-		'DEU': 0,
-		'HUN': 0,
-		'ITA': 0,
-		'PLK': 0,
-		'PTB': 0,
-		'ROM': 0,
-		'RUS': 0,
-		'ESP': 0,
-		'TRK': 0,
-		'VIN': 0,
-	}
-	async def _translate(self, from_lang, to_lang, queries):
-		return ''
+
+class NoneTranslator(CommonTranslator):
+	
+	def supports_languages(self, from_lang: str, to_lang: str, fatal: bool = False) -> bool:
+		return True
+
+	async def _translate(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:
+		return ['' for query in queries]

--- a/translators/selective.py
+++ b/translators/selective.py
@@ -64,7 +64,7 @@ class SelectiveOfflineTranslator(OfflineTranslator):
         return get_translator('nnlb')
 
     async def translate(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:
-        self._real_translator = self._select_translator(from_lang, to_lang, queries)
+        self._real_translator = self.select_translator(from_lang, to_lang, queries)
         print(f'-- Selected translator: {self._real_translator.__class__.__name__}')
 
         if self._cached_load_params:
@@ -78,6 +78,15 @@ class SelectiveOfflineTranslator(OfflineTranslator):
 
     async def reload(self, from_lang: str, to_lang: str, device: str):
         self._cached_load_params = [from_lang, to_lang, device]
+
+    async def _load(self, from_lang: str, to_lang: str, device: str):
+        pass
+
+    async def _unload(self):
+        pass
+
+    async def _forward(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:
+        pass
 
 class SelectiveBigOfflineTranslator(SelectiveOfflineTranslator):
     def _select_translator(self, from_lang: str, to_lang: str) -> OfflineTranslator:

--- a/translators/sugoi.py
+++ b/translators/sugoi.py
@@ -5,7 +5,7 @@ from fairseq.models.transformer import TransformerModel
 
 from .common import OfflineTranslator
 
-class JParaCrawlTranslator(OfflineTranslator):
+class SugoiTranslator(OfflineTranslator):
     _LANGUAGE_CODE_MAP = {
         'JPN': 'ja',
         'ENG': 'en',
@@ -111,13 +111,13 @@ class JParaCrawlTranslator(OfflineTranslator):
         #text = ' '.join(text.split()).replace('▁', '').strip()
         return text
 
-class JParaCrawlSmallTranslator(JParaCrawlTranslator):
+class SugoiSmallTranslator(SugoiTranslator):
     _MODEL_FILES = {
         'ja-en': 'small.pretrain.ja-en.pt',
         'en-ja': 'small.pretrain.en-ja.pt',
     }
     _MODEL_MAPPING = {
-        **JParaCrawlTranslator._MODEL_MAPPING,
+        **SugoiTranslator._MODEL_MAPPING,
         'model-ja-en': {
             'url': 'http://www.kecl.ntt.co.jp/icl/lirg/jparacrawl/release/3.0/pretrained_models/ja-en/small.tar.gz',
             'hash': '7136FE12841C626B105A9E588F858A8E0B76E451B19839457D7473EC705D12B3',
@@ -140,13 +140,13 @@ class JParaCrawlSmallTranslator(JParaCrawlTranslator):
         },
     }
 
-class JParaCrawlBigTranslator(JParaCrawlTranslator):
+class SugoiBigTranslator(SugoiTranslator):
     _MODEL_FILES = {
         'ja-en': 'big.pretrain.ja-en.pt',
         'en-ja': 'big.pretrain.en-ja.pt',
     }
     _MODEL_MAPPING = {
-        **JParaCrawlTranslator._MODEL_MAPPING,
+        **SugoiTranslator._MODEL_MAPPING,
         'model-ja-en': {
             'url': 'http://www.kecl.ntt.co.jp/icl/lirg/jparacrawl/release/3.0/pretrained_models/ja-en/big.tar.gz',
             'hash': '7517753B6FEB8594D3C86AD7742DBC49203115ADD21E8A6C7542AA2AC0DF1C6A',

--- a/web_main.py
+++ b/web_main.py
@@ -84,7 +84,7 @@ async def handle_post(request):
 			direction = 'auto'
 	if 'translator' in data:
 		selected_translator = data['translator'].lower()
-		if selected_translator not in ['youdao', 'baidu', 'google', 'deepl', 'papago', 'offline', 'null']:
+		if selected_translator not in ['youdao', 'baidu', 'google', 'deepl', 'papago', 'offline', 'none']:
 			selected_translator = 'youdao'
 	if 'size' in data:
 		size = data['size'].upper()

--- a/web_main.py
+++ b/web_main.py
@@ -7,11 +7,10 @@ from PIL import Image
 from oscrypto import util as crypto_utils
 from aiohttp import web
 from io import BytesIO
-
 from imagehash import phash
 from collections import deque
 
-from translators import VALID_LANGUAGES, dispatch as run_translation
+from translators import VALID_LANGUAGES, dispatch as dispatch_translation
 
 VALID_DETECTORS = set(['default', 'ctd'])
 VALID_DIRECTIONS = set(['auto', 'horizontal'])
@@ -169,7 +168,7 @@ async def machine_trans_task(task_id, texts, translator = 'youdao', target_langu
 		success = False
 		for _ in range(10):
 			try:
-				TASK_DATA[task_id]['trans_result'] = await asyncio.wait_for(run_translation(translator, 'auto', target_language, texts), timeout = 15)
+				TASK_DATA[task_id]['trans_result'] = await asyncio.wait_for(dispatch_translation(translator, 'auto', target_language, texts), timeout = 15)
 				success = True
 				break
 			except Exception as ex:


### PR DESCRIPTION
- Made adding new ocrs easier by adding common interface class (Will help advance #104)
- Made ocr models being automatically downloaded from github release page into `models` directory (Might cause confusion due to user still having to download the other models into the base folder)
- Added choices to argument parser

Perhaps it would be possible to add the `alphabet-all-v5.txt` file into the release page since it technically belongs to the ocr models?