### PR TITLE
Rearrange image to handle extreme aspect ratio

### DIFF
--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -38,7 +38,7 @@ async def run_default(img: np.ndarray, detect_size: int, cuda: bool, verbose: bo
 	global DEFAULT_MODEL
 	device = 'cuda' if cuda else 'cpu'
 
-	db, mask = det_rearrange_forward(img, det_batch_forward_default, detect_size, device=device, verbose=verbose)
+	db, mask = det_rearrange_forward(img, det_batch_forward_default, detect_size, args.det_rearrange_max_batches, device=device, verbose=verbose)
 	
 	if db is None:
 		# rearrangement is not required, fallback to default forward

--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -1,9 +1,9 @@
 
 import torch
 import cv2
-from typing import List
+from typing import List, Tuple
 import numpy as np
-from utils import Quadrilateral
+from utils import Quadrilateral, det_rearrange_forward
 from .DBNet_resnet34 import TextDetection as TextDetectionDefault
 from . import imgproc, dbnet_utils, craft_utils
 import einops
@@ -23,23 +23,40 @@ def load_model(cuda: bool, model_name: str = 'default'):
 			model = model.cuda()
 		DEFAULT_MODEL = model
 
+def det_batch_forward_default(batch: np.ndarray, device: str) -> Tuple[np.ndarray, np.ndarray]:
+	if isinstance(batch, list):
+		batch = np.array(batch)
+	batch = einops.rearrange(batch.astype(np.float32) / 127.5 - 1.0, 'n h w c -> n c h w')
+	batch = torch.from_numpy(batch).to(device)
+	with torch.no_grad():
+		db, mask = DEFAULT_MODEL(batch)
+		db = db.sigmoid().cpu().numpy()
+		mask = mask.cpu().numpy()
+	return db, mask
+
 async def run_default(img: np.ndarray, detect_size: int, cuda: bool, verbose: bool, args: dict):
 	global DEFAULT_MODEL
-	img_resized, target_ratio, _, pad_w, pad_h = imgproc.resize_aspect_ratio(cv2.bilateralFilter(img, 17, 80, 80), detect_size, cv2.INTER_LINEAR, mag_ratio = 1)
-	ratio_h = ratio_w = 1 / target_ratio
-	if verbose:
-		print(f'Detection resolution: {img_resized.shape[1]}x{img_resized.shape[0]}')
-	img_resized = img_resized.astype(np.float32) / 127.5 - 1.0
-	img = torch.from_numpy(img_resized)
-	if cuda:
-		img = img.cuda()
-	img = einops.rearrange(img, 'h w c -> 1 c h w')
-	with torch.no_grad():
-		db, mask = DEFAULT_MODEL(img)
-		db = db.sigmoid().cpu()
-		mask = mask[0, 0, :, :].cpu().numpy()
+	device = 'cuda' if cuda else 'cpu'
+
+	db, mask = det_rearrange_forward(img, det_batch_forward_default, detect_size, device=device, verbose=verbose)
+	
+	if db is None:
+		img_resized, target_ratio, _, pad_w, pad_h = imgproc.resize_aspect_ratio(cv2.bilateralFilter(img, 17, 80, 80), detect_size, cv2.INTER_LINEAR, mag_ratio = 1)
+		img_resized_h, img_resized_w = img_resized.shape[:2]
+		ratio_h = ratio_w = 1 / target_ratio
+		if verbose:
+			print(f'Detection resolution: {img_resized_w}x{img_resized_h}')
+		db, mask = det_batch_forward_default([img_resized], device)
+	else:
+		if verbose:
+			print(f'Patchify image before performimg detection')
+		img_resized_h, img_resized_w = img.shape[:2]
+		ratio_w = ratio_h = 1
+		pad_h = pad_w = 0
+
+	mask = mask[0, 0, :, :]
 	det = dbnet_utils.SegDetectorRepresenter(args.text_threshold, args.box_threshold, unclip_ratio = args.unclip_ratio)
-	boxes, scores = det({'shape':[(img_resized.shape[0], img_resized.shape[1])]}, db)
+	boxes, scores = det({'shape':[(img_resized_h, img_resized_w)]}, db)
 	boxes, scores = boxes[0], scores[0]
 	if boxes.size == 0:
 		polys = []

--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -41,6 +41,7 @@ async def run_default(img: np.ndarray, detect_size: int, cuda: bool, verbose: bo
 	db, mask = det_rearrange_forward(img, det_batch_forward_default, detect_size, device=device, verbose=verbose)
 	
 	if db is None:
+		# rearrangement is not required, fallback to default forward
 		img_resized, target_ratio, _, pad_w, pad_h = imgproc.resize_aspect_ratio(cv2.bilateralFilter(img, 17, 80, 80), detect_size, cv2.INTER_LINEAR, mag_ratio = 1)
 		img_resized_h, img_resized_w = img_resized.shape[:2]
 		ratio_h = ratio_w = 1 / target_ratio
@@ -48,8 +49,6 @@ async def run_default(img: np.ndarray, detect_size: int, cuda: bool, verbose: bo
 			print(f'Detection resolution: {img_resized_w}x{img_resized_h}')
 		db, mask = det_batch_forward_default([img_resized], device)
 	else:
-		if verbose:
-			print(f'Patchify image before performimg detection')
 		img_resized_h, img_resized_w = img.shape[:2]
 		ratio_w = ratio_h = 1
 		pad_h = pad_w = 0

--- a/inpainting/inpainting_lama_mpe.py
+++ b/inpainting/inpainting_lama_mpe.py
@@ -715,34 +715,37 @@ class LamaFourier:
         pos = np.zeros((h, w), dtype=np.int32)
         direct = np.zeros((h, w, 4), dtype=np.int32)
         i = 0
-        while np.sum(1 - mask3) > 0:
-            i += 1
-            mask3_ = cv2.filter2D(mask3, -1, ones_filter)
-            mask3_[mask3_ > 0] = 1
-            sub_mask = mask3_ - mask3
-            pos[sub_mask == 1] = i
 
-            m = cv2.filter2D(mask3, -1, d_filter1)
-            m[m > 0] = 1
-            m = m - mask3
-            direct[m == 1, 0] = 1
+        if mask3.max() > 0:
+            # otherwise it will cause infinity loop
+            while np.sum(1 - mask3) > 0:
+                i += 1
+                mask3_ = cv2.filter2D(mask3, -1, ones_filter)
+                mask3_[mask3_ > 0] = 1
+                sub_mask = mask3_ - mask3
+                pos[sub_mask == 1] = i
 
-            m = cv2.filter2D(mask3, -1, d_filter2)
-            m[m > 0] = 1
-            m = m - mask3
-            direct[m == 1, 1] = 1
+                m = cv2.filter2D(mask3, -1, d_filter1)
+                m[m > 0] = 1
+                m = m - mask3
+                direct[m == 1, 0] = 1
 
-            m = cv2.filter2D(mask3, -1, d_filter3)
-            m[m > 0] = 1
-            m = m - mask3
-            direct[m == 1, 2] = 1
+                m = cv2.filter2D(mask3, -1, d_filter2)
+                m[m > 0] = 1
+                m = m - mask3
+                direct[m == 1, 1] = 1
 
-            m = cv2.filter2D(mask3, -1, d_filter4)
-            m[m > 0] = 1
-            m = m - mask3
-            direct[m == 1, 3] = 1
+                m = cv2.filter2D(mask3, -1, d_filter3)
+                m[m > 0] = 1
+                m = m - mask3
+                direct[m == 1, 2] = 1
 
-            mask3 = mask3_
+                m = cv2.filter2D(mask3, -1, d_filter4)
+                m[m > 0] = 1
+                m = m - mask3
+                direct[m == 1, 3] = 1
+
+                mask3 = mask3_
 
         abs_pos = pos.copy()
         rel_pos = pos / (str_size / 2)  # to 0~1 maybe larger than 1

--- a/ocr/model_32px.py
+++ b/ocr/model_32px.py
@@ -54,8 +54,10 @@ class Model32pxOCR(OfflineOCR):
         out_regions = []
 
         perm = range(len(regions))
+        is_quadrilaterals = False
         if len(quadrilaterals) > 0 and isinstance(quadrilaterals[0][0], Quadrilateral):
             perm = sorted(range(len(regions)), key = lambda x: regions[x].shape[1])
+            is_quadrilaterals = True
 
         ix = 0
         for indices in chunks(perm, max_chunk_size):
@@ -120,7 +122,10 @@ class Model32pxOCR(OfflineOCR):
                     cur_region.bg_b += bb
 
                 out_regions.append(cur_region)
-        return out_regions
+
+        if is_quadrilaterals:
+            return out_regions
+        return textlines
 
 
 class ResNet(nn.Module):

--- a/ocr/model_48px_ctc.py
+++ b/ocr/model_48px_ctc.py
@@ -90,8 +90,10 @@ class Model48pxCTCOCR(OfflineOCR):
         out_regions = []
 
         perm = range(len(regions))
+        is_quadrilaterals = False
         if len(quadrilaterals) > 0:
             if isinstance(quadrilaterals[0][0], Quadrilateral):
+                is_quadrilaterals = True
                 perm = sorted(range(len(regions)), key = lambda x: regions[x].shape[1])
 
         ix = 0
@@ -169,8 +171,12 @@ class Model48pxCTCOCR(OfflineOCR):
                     cur_region.bg_r += br
                     cur_region.bg_g += bg
                     cur_region.bg_b += bb
+					
                 out_regions.append(cur_region)
-        return out_regions
+
+        if is_quadrilaterals:
+            return out_regions
+        return textlines
 
 
 class PositionalEncoding(nn.Module):

--- a/text_rendering/__init__.py
+++ b/text_rendering/__init__.py
@@ -72,12 +72,16 @@ async def dispatch_ctd_render(img_canvas: np.ndarray, text_mag_ratio: np.integer
 			continue
 
 		majority_dir = None
+		angle_changed = False
 		if text_direction_overwrite in ['h', 'v']:
 			majority_dir = text_direction_overwrite
-		elif 'ENG' in LANGAUGE_ORIENTATION_PRESETS:
-			majority_dir = LANGAUGE_ORIENTATION_PRESETS['ENG']
-		if majority_dir not in ['h', 'v']:
-			majority_dir = region.majority_dir
+		else:
+			if region.vertical:
+				majority_dir = 'v'
+				region.angle += 90
+				angle_changed = True
+			else:
+				majority_dir = 'h'
 
 		fg, bg = region.get_font_colors()
 		fg, bg = fg_bg_compare(fg, bg)
@@ -89,9 +93,10 @@ async def dispatch_ctd_render(img_canvas: np.ndarray, text_mag_ratio: np.integer
 		textlines = []
 		for ii, text in enumerate(region.text):
 			textlines.append(Quadrilateral(np.array(region.lines[ii]), text, 1, region.fg_r, region.fg_g, region.fg_b, region.bg_r, region.bg_g, region.bg_b))
-		# region_aabb = region.aabb
-		# print(region_aabb.x, region_aabb.y, region_aabb.w, region_aabb.h)
+		
 		img_canvas = render(img_canvas, font_size, text_mag_ratio, trans_text, region, majority_dir, fg, bg, True, font_size_offset)
+		if angle_changed:
+			region.angle -= 90
 	return img_canvas
 
 def render(img_canvas, font_size, text_mag_ratio, trans_text, region, majority_dir, fg, bg, is_ctd, font_size_offset: int = 0):
@@ -153,7 +158,6 @@ def render(img_canvas, font_size, text_mag_ratio, trans_text, region, majority_d
 		w_ext = int((h * r - w) / 2)
 		box = np.zeros((h, w + w_ext * 2, 4), dtype=np.uint8)
 		box[0:h, w_ext:w_ext+w] = temp_box
-	#region_ext = round(min(w, h) * 0.05)
 	#h_ext += region_ext
 	#w_ext += region_ext
 

--- a/textblockdetector/__init__.py
+++ b/textblockdetector/__init__.py
@@ -112,9 +112,9 @@ class TextDetector:
         return lines, mask
 
     @torch.no_grad()
-    def __call__(self, img, refine_mode=REFINEMASK_INPAINT, keep_undetected_mask=False, bgr2rgb=True, verbose=False):
+    def __call__(self, img, refine_mode=REFINEMASK_INPAINT, keep_undetected_mask=False, bgr2rgb=True, verbose=False, det_rearrange_max_batches=4):
         im_h, im_w = img.shape[:2]
-        lines_map, mask = det_rearrange_forward(img, self.det_batch_forward_ctd, self.input_size[0], device=self.device, verbose=verbose)
+        lines_map, mask = det_rearrange_forward(img, self.det_batch_forward_ctd, self.input_size[0], det_rearrange_max_batches, self.device, verbose)
         blks = []
         resize_ratio = [1, 1]
         if lines_map is None:
@@ -162,8 +162,8 @@ def load_model(cuda: bool):
         model = TextDetector(model_path='comictextdetector.pt.onnx', device=device, act='leaky', input_size=1024)
     DEFAULT_MODEL = model
 
-async def dispatch(img: np.ndarray, cuda: bool, verbose: bool = False):
+async def dispatch(img: np.ndarray, cuda: bool, verbose: bool = False, det_rearrange_max_batches: int = 4):
     global DEFAULT_MODEL
     if DEFAULT_MODEL is None:
         load_model(cuda)
-    return DEFAULT_MODEL(img, refine_mode=REFINEMASK_INPAINT, keep_undetected_mask=False, bgr2rgb=False, verbose=verbose)
+    return DEFAULT_MODEL(img, refine_mode=REFINEMASK_INPAINT, keep_undetected_mask=False, bgr2rgb=False, verbose=verbose, det_rearrange_max_batches=det_rearrange_max_batches)

--- a/textblockdetector/__init__.py
+++ b/textblockdetector/__init__.py
@@ -2,18 +2,21 @@ import json
 from .basemodel import TextDetBase, TextDetBaseDNN
 import os.path as osp
 from tqdm import tqdm
+import einops
 import numpy as np
 import cv2
 import torch
 from pathlib import Path
 import torch
-from typing import Union
+from typing import Union, Tuple
 from .utils.yolov5_utils import non_max_suppression
 from .utils.db_utils import SegDetectorRepresenter
 from .utils.io_utils import imread, imwrite, find_all_imgs, NumpyEncoder
 from .utils.imgproc_utils import letterbox, xyxy2yolo, get_yololabel_strings
 from .textblock import TextBlock, group_output
 from .textmask import refine_mask, refine_undetected_mask, REFINEMASK_INPAINT, REFINEMASK_ANNOTATION
+
+from utils import det_rearrange_forward
 
 def preprocess_img(img, input_size=(1024, 1024), device='cpu', bgr2rgb=True, half=False, to_tensor=True):
     if bgr2rgb:
@@ -33,7 +36,7 @@ def postprocess_mask(img: Union[torch.Tensor, np.ndarray], thresh=None):
     if isinstance(img, torch.Tensor):
         img = img.squeeze_()
         if img.device != 'cpu':
-            img = img.detach_().cpu()
+            img = img.detach().cpu()
         img = img.numpy()
     else:
         img = img.squeeze()
@@ -58,6 +61,7 @@ def postprocess_yolo(det, conf_thresh, nms_thresh, resize_ratio, sort_func=None)
     confs = np.round(det[..., 4], 3)
     cls = det[..., 5].astype(np.int32)
     return blines, cls, confs
+
 
 class TextDetector:
     lang_list = ['eng', 'ja', 'unknown']
@@ -84,38 +88,61 @@ class TextDetector:
         self.nms_thresh = nms_thresh
         self.seg_rep = SegDetectorRepresenter(thresh=0.3)
 
+    def det_batch_forward_ctd(self, batch: np.ndarray, device: str) -> Tuple[np.ndarray, np.ndarray]:
+        
+        if isinstance(self.net, TextDetBase):
+            batch = einops.rearrange(batch.astype(np.float32) / 255., 'n h w c -> n c h w')
+            batch = torch.from_numpy(batch).to(device)
+            _, mask, lines = self.net(batch)
+            mask = mask.cpu().numpy()
+            lines = lines.cpu().numpy()
+        elif isinstance(self.net, TextDetBaseDNN):
+            mask_lst, line_lst = [], []
+            for b in batch:
+                _, mask, lines = self.net(b)
+                if mask.shape[1] == 2:     # some version of opencv spit out reversed result
+                    tmp = mask
+                    mask = lines
+                    lines = tmp
+                mask_lst.append(mask)
+                line_lst.append(lines)
+            lines, mask = np.concatenate(line_lst, 0), np.concatenate(mask_lst, 0)
+        else:
+            raise NotImplementedError
+        return lines, mask
+
     @torch.no_grad()
-    def __call__(self, img, refine_mode=REFINEMASK_INPAINT, keep_undetected_mask=False, bgr2rgb=True):
-        img_in, ratio, dw, dh = preprocess_img(img, input_size=self.input_size, device=self.device, half=self.half, to_tensor=self.backend=='torch')
-
+    def __call__(self, img, refine_mode=REFINEMASK_INPAINT, keep_undetected_mask=False, bgr2rgb=True, verbose=False):
         im_h, im_w = img.shape[:2]
+        lines_map, mask = det_rearrange_forward(img, self.det_batch_forward_ctd, self.input_size[0], device=self.device, verbose=verbose)
+        blks = []
+        resize_ratio = [1, 1]
+        if lines_map is None:
+            img_in, ratio, dw, dh = preprocess_img(img, input_size=self.input_size, device=self.device, half=self.half, to_tensor=self.backend=='torch')
+            blks, mask, lines_map = self.net(img_in)
 
-        blks, mask, lines_map = self.net(img_in)
+            if self.backend == 'opencv':
+                if mask.shape[1] == 2:     # some version of opencv spit out reversed result
+                    tmp = mask
+                    mask = lines_map
+                    lines_map = tmp
+            mask = mask.squeeze()
+            resize_ratio = (im_w / (self.input_size[0] - dw), im_h / (self.input_size[1] - dh))
+            blks = postprocess_yolo(blks, self.conf_thresh, self.nms_thresh, resize_ratio)
+            mask = mask[..., :mask.shape[0]-dh, :mask.shape[1]-dw]
+            lines_map = lines_map[..., :lines_map.shape[2]-dh, :lines_map.shape[3]-dw]
 
-        resize_ratio = (im_w / (self.input_size[0] - dw), im_h / (self.input_size[1] - dh))
-        blks = postprocess_yolo(blks, self.conf_thresh, self.nms_thresh, resize_ratio)
-
-        if self.backend == 'opencv':
-            if mask.shape[1] == 2:     # some version of opencv spit out reversed result
-                tmp = mask
-                mask = lines_map
-                lines_map = tmp
         mask = postprocess_mask(mask)
-
-        lines, scores = self.seg_rep(self.input_size, lines_map)
+        lines, scores = self.seg_rep(None, lines_map, height=im_h, width=im_w)
         box_thresh = 0.6
         idx = np.where(scores[0] > box_thresh)
         lines, scores = lines[0][idx], scores[0][idx]
 
         # map output to input img
-        mask = mask[: mask.shape[0]-dh, : mask.shape[1]-dw]
         mask = cv2.resize(mask, (im_w, im_h), interpolation=cv2.INTER_LINEAR)
         if lines.size == 0:
             lines = []
         else:
-            lines = lines.astype(np.float64)
-            lines[..., 0] *= resize_ratio[0]
-            lines[..., 1] *= resize_ratio[1]
             lines = lines.astype(np.int32)
         blk_list = group_output(blks, lines, im_w, im_h, mask)
         mask_refined = refine_mask(img, mask, blk_list, refine_mode=refine_mode)
@@ -135,8 +162,8 @@ def load_model(cuda: bool):
         model = TextDetector(model_path='comictextdetector.pt.onnx', device=device, act='leaky', input_size=1024)
     DEFAULT_MODEL = model
 
-async def dispatch(img: np.ndarray, cuda: bool):
+async def dispatch(img: np.ndarray, cuda: bool, verbose: bool = False):
     global DEFAULT_MODEL
     if DEFAULT_MODEL is None:
         load_model(cuda)
-    return DEFAULT_MODEL(img, refine_mode=REFINEMASK_INPAINT, keep_undetected_mask=False, bgr2rgb=False)
+    return DEFAULT_MODEL(img, refine_mode=REFINEMASK_INPAINT, keep_undetected_mask=False, bgr2rgb=False, verbose=verbose)

--- a/textblockdetector/textblock.py
+++ b/textblockdetector/textblock.py
@@ -515,12 +515,12 @@ def group_output(blks, lines, im_w, im_h, mask=None, sort_blklist=True) -> List[
 		final_blk_list = sort_textblk_list(final_blk_list, im_w, im_h)
 
 	for blk in final_blk_list:
-		if blk.language == 'eng' and not blk.vertical:
+		if blk.language != 'ja' and not blk.vertical:
 			num_lines = len(blk.lines)
 			if num_lines == 0:
 				continue
 			# blk.line_spacing = blk.bounding_rect()[3] / num_lines / blk.font_size
-			expand_size = max(int(blk.font_size * 0.1), 2)
+			expand_size = max(int(blk.font_size * 0.1), 3)
 			rad = np.deg2rad(blk.angle)
 			shifted_vec = np.array([[[-1, -1],[1, -1],[1, 1],[-1, 1]]])
 			shifted_vec = shifted_vec * np.array([[[np.sin(rad), np.cos(rad)]]]) * expand_size

--- a/textblockdetector/textblock.py
+++ b/textblockdetector/textblock.py
@@ -363,7 +363,7 @@ def examine_textblk(blk: TextBlock, im_w: int, im_h: int, sort: bool = False) ->
 	if sort:
 		blk.sort_lines()
 
-def try_merge_textline(blk: TextBlock, blk2: TextBlock, fntsize_tol=1.3, distance_tol=2) -> bool:
+def try_merge_textline(blk: TextBlock, blk2: TextBlock, fntsize_tol=1.4, distance_tol=2) -> bool:
 	if blk2.merged:
 		return False
 	fntsize_div = blk.font_size / blk2.font_size
@@ -380,7 +380,10 @@ def try_merge_textline(blk: TextBlock, blk2: TextBlock, fntsize_tol=1.3, distanc
 			return False
 		if abs(cos_vec) < 0.866:   # cos30
 			return False
-		if distance > distance_tol * fntsz_avg or distance_p1 > fntsz_avg * 2.5:
+		# if distance > distance_tol * fntsz_avg or distance_p1 > fntsz_avg * 2.5:
+		if distance > distance_tol * fntsz_avg:
+			return False
+		if blk.vertical and blk2.vertical and distance_p1 > fntsz_avg * 2.5:
 			return False
 	# merge
 	blk.lines.append(blk2.lines[0])

--- a/textblockdetector/textmask.py
+++ b/textblockdetector/textmask.py
@@ -3,7 +3,7 @@ from typing import List
 import cv2
 import numpy as np
 from .textblock import TextBlock
-from .utils.imgproc_utils import draw_connected_labels, expand_textwindow, union_area
+from .utils.imgproc_utils import draw_connected_labels, union_area, enlarge_window
 
 WHITE = (255, 255, 255)
 BLACK = (0, 0, 0)
@@ -159,12 +159,18 @@ def refine_undetected_mask(img: np.ndarray, mask_pred: np.ndarray, mask_refined:
 def refine_mask(img: np.ndarray, pred_mask: np.ndarray, blk_list: List[TextBlock], refine_mode: int = REFINEMASK_INPAINT) -> np.ndarray:
     mask_refined = np.zeros_like(pred_mask)
     for blk in blk_list:
-        bx1, by1, bx2, by2 = expand_textwindow(img.shape, blk.xyxy, expand_r=16)
+        bx1, by1, bx2, by2 = enlarge_window(blk.xyxy, img.shape[1], img.shape[0])
         im = np.ascontiguousarray(img[by1: by2, bx1: bx2])
         msk = np.ascontiguousarray(pred_mask[by1: by2, bx1: bx2])
+
         mask_list = get_topk_masklist(im, msk)
         mask_list += get_otsuthresh_masklist(im, msk, per_channel=False)
         mask_merged = merge_mask_list(mask_list, msk, blk=blk, text_window=[bx1, by1, bx2, by2], refine_mode=refine_mode)
         mask_refined[by1: by2, bx1: bx2] = cv2.bitwise_or(mask_refined[by1: by2, bx1: bx2], mask_merged)
+        # cv2.imshow('im', im)
+        # cv2.imshow('msk', msk)
+        # cv2.imshow('mask_refined', mask_refined[by1: by2, bx1: bx2])
+        # cv2.waitKey(0)
+    
     return mask_refined
 

--- a/translate_demo.py
+++ b/translate_demo.py
@@ -37,6 +37,7 @@ parser.add_argument('--translator', default='google', type=str, choices=TRANSLAT
 parser.add_argument('--use-cuda', action='store_true', help='Turn on/off cuda')
 parser.add_argument('--use-cuda-limited', action='store_true', help='Turn on/off cuda (excluding offline translator)')
 parser.add_argument('--detection-size', default=1536, type=int, help='Size of image used for detection')
+parser.add_argument('--det-rearrange-max-batches', default=4, type=int, help='Max batch size produced by the rearrangement of image with extreme aspectio, reduce it if cuda OOM')
 parser.add_argument('--inpainting-size', default=2048, type=int, help='Size of image used for inpainting (too large will result in OOM)')
 parser.add_argument('--unclip-ratio', default=2.3, type=float, help='How much to extend text skeleton to form bounding box')
 parser.add_argument('--box-threshold', default=0.7, type=float, help='Threshold for bbox generation')
@@ -152,7 +153,7 @@ async def infer(
 		update_state(task_id, nonce, 'detection')
 
 	if detector == 'ctd':
-		mask, final_mask, textlines = await dispatch_ctd_detection(img, args.use_cuda, args.verbose)
+		mask, final_mask, textlines = await dispatch_ctd_detection(img, args.use_cuda, args.verbose, args.det_rearrange_max_batches)
 	else:
 		textlines, mask = await dispatch_detection(img, img_detect_size, args.use_cuda, args, verbose = args.verbose)
 

--- a/translate_demo.py
+++ b/translate_demo.py
@@ -152,7 +152,7 @@ async def infer(
 		update_state(task_id, nonce, 'detection')
 
 	if detector == 'ctd':
-		mask, final_mask, textlines = await dispatch_ctd_detection(img, args.use_cuda)
+		mask, final_mask, textlines = await dispatch_ctd_detection(img, args.use_cuda, args.verbose)
 	else:
 		textlines, mask = await dispatch_detection(img, img_detect_size, args.use_cuda, args, verbose = args.verbose)
 

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import os
 import stat
-from typing import List
+from typing import List, Callable, Tuple
 import numpy as np
 import cv2
 import functools
@@ -960,11 +960,17 @@ def square_pad_resize(img: np.ndarray, tgt_size: int):
 
 	return img, down_scale_ratio, pad_h, pad_w
 
-def det_rearrange_forward(img: np.ndarray, dbnet_batch_forward, tgt_size: int = 1280, max_batch_size=4, device='cuda', verbose=False):
+def det_rearrange_forward(
+	img: np.ndarray, 
+	dbnet_batch_forward: Callable[[np.ndarray, str], Tuple[np.ndarray, np.ndarray]], 
+	tgt_size: int = 1280, 
+	max_batch_size: int = 4, 
+	device='cuda', verbose=False):
 	'''
 	Rearrange image to square batches before feeding into network if following conditions are satisfied: \n
 	1. Extreme aspect ratio
 	2. Is too tall or wide for detect size (tgt_size)
+
 	Returns:
         DBNet output, mask or None, None if rearrangement is not required
 	'''

--- a/utils.py
+++ b/utils.py
@@ -16,6 +16,7 @@ import re
 import torch
 import shutil
 import filecmp
+import einops
 
 try:
   	functools.cached_property
@@ -25,9 +26,9 @@ except AttributeError: # Supports Python versions below 3.8
 
 
 def chunks(lst, n):
-    """Yield successive n-sized chunks from lst."""
-    for i in range(0, len(lst), n):
-        yield lst[i:i + n]
+	"""Yield successive n-sized chunks from lst."""
+	for i in range(0, len(lst), n):
+		yield lst[i:i + n]
 
 def get_digest(file_path: str) -> str:
 	h = hashlib.sha256()
@@ -262,10 +263,10 @@ class ModelWrapper(ABC):
 						shutil.move(p1, p2)
 					else:
 						raise InvalidModelMappingException(self.__class__.__name__, map_key, 'File "{orig}" does not exist within archive' +
-								        '\nAvailable files:\n%s' % '\n'.join(get_real_archive_files()))
+										'\nAvailable files:\n%s' % '\n'.join(get_real_archive_files()))
 				if len(map['archive']) == 0:
 					raise InvalidModelMappingException(self.__class__.__name__, map_key, 'No archive files specified' +
-					                    '\nAvailable files:\n%s' % '\n'.join(get_real_archive_files()))
+										'\nAvailable files:\n%s' % '\n'.join(get_real_archive_files()))
 
 				self._grant_execute_permissions(map_key)
 
@@ -931,6 +932,146 @@ def color_difference(rgb1: List, rgb2: List) -> float:
 	diff[..., 0] *= 0.392
 	diff = np.linalg.norm(diff, axis=2) 
 	return diff.item()
+
+def square_pad_resize(img: np.ndarray, tgt_size: int):
+	h, w = img.shape[:2]
+	pad_h, pad_w = 0, 0
+	
+	# make square image
+	if w < h:
+		pad_w = h - w
+		w += pad_w
+	elif h < w:
+		pad_h = w - h
+		h += pad_h
+
+	pad_size = tgt_size - h
+	if pad_size > 0:
+		pad_h += pad_size
+		pad_w += pad_size
+
+	if pad_h > 0 or pad_w > 0:	
+		img = cv2.copyMakeBorder(img, 0, pad_h, 0, pad_w, cv2.BORDER_CONSTANT)
+
+	down_scale_ratio = tgt_size / img.shape[0]
+	assert down_scale_ratio <= 1
+	if down_scale_ratio < 1:
+		img = cv2.resize(img, (tgt_size, tgt_size), interpolation=cv2.INTER_LINEAR)
+
+	return img, down_scale_ratio, pad_h, pad_w
+
+def det_rearrange_forward(img: np.ndarray, dbnet_batch_forward, tgt_size: int = 1280, max_batch_size=4, device='cuda', verbose=False):
+	'''
+	Rearrange image to square batches before feeding into network if it satisfies following conditions: \n
+	1. Extreme aspect ratio
+	2. Is too tall or wide for detect size (tgt_size)
+	'''
+
+	def _unpatchify(patch_lst: List[np.ndarray], transpose: bool, channel=1, pad_num=0):
+		_psize = _h = patch_lst[0].shape[-1]
+		_step = int(ph_step * _psize / patch_size)
+		_pw = int(_psize / pw_num)
+		if ph_num > 1:
+			_h += (ph_num - 1) * _step
+		tgtmap = np.zeros((channel, _h, _pw), dtype=np.float32)
+		num_patches = len(patch_lst) * pw_num - pad_num
+		for ii, p in enumerate(patch_lst):
+			if transpose:
+				p = einops.rearrange(p, 'c h w -> c w h')
+			for jj in range(pw_num):
+				pidx = ii * pw_num + jj
+				t = pidx * _step
+				b = t + _psize
+				l = jj * _pw
+				r = l + _pw
+
+				tgtmap[..., t: b, :] += p[..., l: r]
+				if pidx > 0:
+					interleave = _psize - _step
+					tgtmap[..., t: t+interleave, :] /= 2.
+
+				if pidx >= num_patches - 1:
+					break
+		if transpose:
+			tgtmap = einops.rearrange(tgtmap, 'c h w -> c w h')
+		return tgtmap[None, ...]
+
+	def _patch2batches(patch_lst: List[np.ndarray], p_num: int, transpose: bool):
+		if transpose:
+			patch_lst = einops.rearrange(patch_lst, '(p_num pw_num) ph pw c -> p_num (pw_num pw) ph c', p_num=p_num)
+		else:
+			patch_lst = einops.rearrange(patch_lst, '(p_num pw_num) ph pw c -> p_num ph (pw_num pw) c', p_num=p_num)
+		
+		batches = [[]]
+		for ii, patch in enumerate(patch_lst):
+
+			if len(batches[-1]) >= max_batch_size:
+				batches.append([])
+			p, down_scale_ratio, pad_h, pad_w = square_pad_resize(patch, tgt_size=tgt_size)
+
+			assert pad_h == pad_w
+			pad_size = pad_h
+			batches[-1].append(p)
+			if verbose:
+				cv2.imwrite(f'result/rearrange_{ii}.jpg', p[..., ::-1])
+		return batches, down_scale_ratio, pad_size
+
+	h, w = img.shape[:2]
+	transpose = False
+	if h < w:
+		transpose = True
+		h, w = img.shape[1], img.shape[0]
+
+	asp_ratio = h / w
+	down_scale_ratio = h / tgt_size
+
+	# rearrange condition
+	require_rearrange = down_scale_ratio > 2.5 and asp_ratio > 3
+	if not require_rearrange:
+		return None, None
+	else:
+
+		if verbose:
+			print(f'Input image will be rearranged to square batches before fed into network.\
+				\n Rearranged batches will be saved to result/rearrange_%d.jpg')
+
+		if transpose:
+			img = einops.rearrange(img, 'h w c -> w h c')
+		
+		pw_num = max(int(np.floor(2 * tgt_size / w)), 2)
+		patch_size = ph = pw_num * w
+
+		ph_num = int(np.ceil(h / ph))
+		ph_step = int((h - ph) / (ph_num - 1)) if ph_num > 1 else 0
+		patch_list = []
+		for ii in range(ph_num):
+			patch_list.append(img[ii * ph_step: ii * ph_step + ph])
+
+		p_num = int(np.ceil(ph_num / pw_num))
+		pad_num = p_num * pw_num - ph_num
+		for ii in range(pad_num):
+			patch_list.append(np.zeros_like(patch_list[0]))
+
+		batches, down_scale_ratio, pad_size = _patch2batches(patch_list, p_num, transpose)
+
+		db_lst, mask_lst = [], []
+		for batch in batches:
+			batch = np.array(batch)
+			db, mask = dbnet_batch_forward(batch, device=device)
+
+			for d, m in zip(db, mask):
+				if pad_size > 0:
+					paddb = int(db.shape[-1] / tgt_size * pad_size)
+					padmsk = int(mask.shape[-1] / tgt_size * pad_size)
+					d = d[..., :-paddb, :-paddb]
+					m = m[..., :-padmsk, :-padmsk]
+				db_lst.append(d)
+				mask_lst.append(m)
+
+		db = _unpatchify(db_lst, transpose, channel=2, pad_num=pad_num)
+		mask = _unpatchify(mask, transpose, channel=1, pad_num=pad_num)
+		return db, mask
+
 
 def main():
 	s1 = [Point(0, 0), Point(0, 2), Point(2, 2), Point(2, 0)]

--- a/utils.py
+++ b/utils.py
@@ -962,12 +962,12 @@ def square_pad_resize(img: np.ndarray, tgt_size: int):
 
 def det_rearrange_forward(img: np.ndarray, dbnet_batch_forward, tgt_size: int = 1280, max_batch_size=4, device='cuda', verbose=False):
 	'''
-	Rearrange image to square batches before feeding into network if it satisfies following conditions: \n
+	Rearrange image to square batches before feeding into network if following conditions are satisfied: \n
 	1. Extreme aspect ratio
 	2. Is too tall or wide for detect size (tgt_size)
 	'''
 
-	def _unpatchify(patch_lst: List[np.ndarray], transpose: bool, channel=1, pad_num=0):
+	def _unrearrange(patch_lst: List[np.ndarray], transpose: bool, channel=1, pad_num=0):
 		_psize = _h = patch_lst[0].shape[-1]
 		_step = int(ph_step * _psize / patch_size)
 		_pw = int(_psize / pw_num)
@@ -1068,8 +1068,8 @@ def det_rearrange_forward(img: np.ndarray, dbnet_batch_forward, tgt_size: int = 
 				db_lst.append(d)
 				mask_lst.append(m)
 
-		db = _unpatchify(db_lst, transpose, channel=2, pad_num=pad_num)
-		mask = _unpatchify(mask, transpose, channel=1, pad_num=pad_num)
+		db = _unrearrange(db_lst, transpose, channel=2, pad_num=pad_num)
+		mask = _unrearrange(mask_lst, transpose, channel=1, pad_num=pad_num)
 		return db, mask
 
 

--- a/utils.py
+++ b/utils.py
@@ -1042,7 +1042,7 @@ def det_rearrange_forward(
 
 		if verbose:
 			print(f'Input image will be rearranged to square batches before fed into network.\
-				\n Rearranged batches will be saved to result/rearrange_%d.jpg')
+				\n Rearranged batches will be saved to result/rearrange_%d.png')
 
 		if transpose:
 			img = einops.rearrange(img, 'h w c -> w h c')
@@ -1052,7 +1052,6 @@ def det_rearrange_forward(
 
 		ph_num = int(np.ceil(h / ph))
 		ph_step = int((h - ph) / (ph_num - 1)) if ph_num > 1 else 0
-		rel_ph_step = ph_step / h
 		rel_step_list = []
 		patch_list = []
 		for ii in range(ph_num):

--- a/utils.py
+++ b/utils.py
@@ -965,6 +965,8 @@ def det_rearrange_forward(img: np.ndarray, dbnet_batch_forward, tgt_size: int = 
 	Rearrange image to square batches before feeding into network if following conditions are satisfied: \n
 	1. Extreme aspect ratio
 	2. Is too tall or wide for detect size (tgt_size)
+	Returns:
+        DBNet output, mask or None, None if rearrangement is not required
 	'''
 
 	def _unrearrange(patch_lst: List[np.ndarray], transpose: bool, channel=1, pad_num=0):
@@ -992,6 +994,7 @@ def det_rearrange_forward(img: np.ndarray, dbnet_batch_forward, tgt_size: int = 
 
 				if pidx >= num_patches - 1:
 					break
+
 		if transpose:
 			tgtmap = einops.rearrange(tgtmap, 'c h w -> c w h')
 		return tgtmap[None, ...]


### PR DESCRIPTION
Fix #145, fix #143

Rearrange image to square batches before feeding into network if it satisfies following conditions:
1. Extreme aspect ratio 
AND
2. Is too tall or wide for detect size

which are common to webtoon and vertical comics(条漫)

Test image0 https://user-images.githubusercontent.com/20344446/209716520-d4d4484c-b7e3-49e5-b8c0-effa7e214f5d.jpeg
Test image1 https://user-images.githubusercontent.com/49092250/209435351-186af25b-e3db-421f-9014-d5406bb41c90.png

For example, image1 will be rearranged like this:
![rearrange](https://user-images.githubusercontent.com/51270320/209821007-ec42bfb7-dd16-4ea1-8faa-955515e41526.jpg)
then feed into DBNet. 

Network output will be un-rearranged (logits in overlapped area will be averaged) before generating text polygons. 
DBNet is segmentation-based, presumably truncation caused by the rearrangement won't deteriorate the final text polygons generation if the text line map have all text lines detected even if they're truncated.

## Result 
### CTD
![vertical_comic0_ctd_bboxes](https://user-images.githubusercontent.com/51270320/209820756-b579e0ad-2530-4545-913f-164fb07eba1c.png)
![vertical_comic1_bboxes_ctd](https://user-images.githubusercontent.com/51270320/209820787-b68ff345-d753-4ffd-94e5-0ab6cca82747.png)

### Default
I can't get image0 to work. Maybe default detection model can't recognize its fonts.

![bboxes](https://user-images.githubusercontent.com/51270320/209824099-7cfe5090-342b-4f4f-8103-8e6c128a7812.png)