### PR TITLE
fix some docker related bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN python -u docker_prepare.py
 
 RUN rm -rf /tmp
 
+# Add /app to Python module path
+ENV PYTHONPATH="${PYTHONPATH}:/app"
+
 WORKDIR /app
 
 ENTRYPOINT ["python", "-m", "manga_translator"]

--- a/demo/doc/docker-compose-web-with-cpu.yml
+++ b/demo/doc/docker-compose-web-with-cpu.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   manga_image_translator:
-    image: zyddnys/manga-image-translator
+    image: zyddnys/manga-image-translator:main
     container_name: manga_image_translator_cpu
     command: --verbose --log-web --mode web --use-inpainting --host=0.0.0.0 --port=5003
     volumes:


### PR DESCRIPTION
1. Execute `docker run -p 5003:5003 -v result:/app/result --ipc=host --rm zyddnys/manga-image-translator:main -l ENG --manga2eng -v --mode web --host=0.0.0.0 --port=5003` will get error: `/opt/conda/bin/python: No module named /app/manga_translator`. So we should add ENV into Dockerfile.
2. compose-file should set specificated version of image.