### PR TITLE
Image.save format paramer Change to use "JPEG" consistently instead when JPG

### DIFF
--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -511,7 +511,7 @@ class MangaTranslatorWeb(MangaTranslator):
         self.nonce = params.get('nonce', '')
         self.ignore_errors = params.get('ignore_errors', True)
         self._task_id = None
-        self._params = None
+        self._params = params
 
     async def _init_connection(self):
         available_translators = []
@@ -587,7 +587,7 @@ class MangaTranslatorWeb(MangaTranslator):
                 log_file = self._result_path('log.txt')
                 add_file_logger(log_file)
 
-            await self.translate_path(self._result_path('input.jpg'), self._result_path('final.jpg'), params=self._params)
+            await self.translate_path(self._result_path('input.jpg'), self._result_path('final.'+self._params.get('format','jpg')), params=self._params)
             print()
 
             if self.verbose:

--- a/manga_translator/server/web_main.py
+++ b/manga_translator/server/web_main.py
@@ -111,7 +111,7 @@ async def result_async(request):
             continue
         im = Image.open(filepath)
         stream = BytesIO()
-        im.save(stream, format=ext.upper())
+        im.save(stream, format="JPEG" if ext == 'jpg' else ext.upper())
         return web.Response(body=stream.getvalue(), content_type=mime[ext])
     # 不存在返回404
     return web.Response(status=404, text="Not Found")

--- a/manga_translator/server/web_main.py
+++ b/manga_translator/server/web_main.py
@@ -186,7 +186,7 @@ async def run_async(request):
         return x
     task_id = f'{phash(img, hash_size = 16)}-{size}-{selected_translator}-{target_language}-{detector}-{direction}'
     print(f'New `run` task {task_id}')
-    if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.png'):
+    if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.webp'):
         return web.json_response({'task_id' : task_id, 'status': 'successful'})
     # elif os.path.exists(f'result/{task_id}'):
     #     # either image is being processed or error occurred
@@ -373,7 +373,7 @@ async def submit_async(request):
     task_id = f'{phash(img, hash_size = 16)}-{size}-{selected_translator}-{target_language}-{detector}-{direction}'
     now = time.time()
     print(f'New `submit` task {task_id}')
-    if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.png'):
+    if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.webp'):
         TASK_STATES[task_id] = {
             'info': 'saved',
             'finished': True,

--- a/manga_translator/server/web_main.py
+++ b/manga_translator/server/web_main.py
@@ -186,7 +186,7 @@ async def run_async(request):
         return x
     task_id = f'{phash(img, hash_size = 16)}-{size}-{selected_translator}-{target_language}-{detector}-{direction}'
     print(f'New `run` task {task_id}')
-    if os.path.exists(f'result/{task_id}/final.jpg'):
+    if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.png'):
         return web.json_response({'task_id' : task_id, 'status': 'successful'})
     # elif os.path.exists(f'result/{task_id}'):
     #     # either image is being processed or error occurred
@@ -373,7 +373,7 @@ async def submit_async(request):
     task_id = f'{phash(img, hash_size = 16)}-{size}-{selected_translator}-{target_language}-{detector}-{direction}'
     now = time.time()
     print(f'New `submit` task {task_id}')
-    if os.path.exists(f'result/{task_id}/final.jpg'):
+    if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.png'):
         TASK_STATES[task_id] = {
             'info': 'saved',
             'finished': True,


### PR DESCRIPTION
The incompatible issue between the "JPG/JPEG" format parameter of Image.save() and certain versions of PIL. Change to use "JPEG" consistently instead when JPG