### PR TITLE
Fixed the phenomenon of console suspended animation in web mode

### DIFF
--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -156,7 +156,7 @@ class MangaTranslator():
     async def _translate_file(self, path: str, dest: str, params: dict):
         if not params.get('overwrite') and os.path.exists(dest):
             logger.info(f'Skipping as already translated: {dest}')
-            #  已存在翻译过的图片时，跳过。实际使用中发现，直接返回 False会出现无法获取新任务 而表现为卡住的现象
+            #  Skip if translated image already exists. In actual use, it is found that if you return False directly, you will not be able to obtain new tasks and appear to be stuck
             await self._report_progress('saved', True)
             return True
         logger.info(f'Translating: {path} -> {dest}')

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -156,7 +156,9 @@ class MangaTranslator():
     async def _translate_file(self, path: str, dest: str, params: dict):
         if not params.get('overwrite') and os.path.exists(dest):
             logger.info(f'Skipping as already translated: {dest}')
-            return False
+            #  已存在翻译过的图片时，跳过。实际使用中发现，直接返回 False会出现无法获取新任务 而表现为卡住的现象
+            await self._report_progress('saved', True)
+            return True
         logger.info(f'Translating: {path} -> {dest}')
 
         try:

--- a/manga_translator/server/web_main.py
+++ b/manga_translator/server/web_main.py
@@ -188,7 +188,7 @@ async def run_async(request):
     print(f'New `run` task {task_id}')
     if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.webp'):
         # Add a console output prompt to avoid the console from appearing to be stuck without execution when the translated image is hit consecutively.
-        print(f'[succeed] The task {task_id} has exists')
+        print('Using cached result for {task_id}')
         return web.json_response({'task_id' : task_id, 'status': 'successful'})
     # elif os.path.exists(f'result/{task_id}'):
     #     # either image is being processed or error occurred

--- a/manga_translator/server/web_main.py
+++ b/manga_translator/server/web_main.py
@@ -187,6 +187,8 @@ async def run_async(request):
     task_id = f'{phash(img, hash_size = 16)}-{size}-{selected_translator}-{target_language}-{detector}-{direction}'
     print(f'New `run` task {task_id}')
     if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.webp'):
+        # 添加控制台输出提示，避免连续出现命中已翻译的图片时，控制台看起来像是不执行而出现了卡顿。
+        print(f'[succeed] The task {task_id} has exists')
         return web.json_response({'task_id' : task_id, 'status': 'successful'})
     # elif os.path.exists(f'result/{task_id}'):
     #     # either image is being processed or error occurred

--- a/manga_translator/server/web_main.py
+++ b/manga_translator/server/web_main.py
@@ -187,7 +187,7 @@ async def run_async(request):
     task_id = f'{phash(img, hash_size = 16)}-{size}-{selected_translator}-{target_language}-{detector}-{direction}'
     print(f'New `run` task {task_id}')
     if os.path.exists(f'result/{task_id}/final.jpg') or os.path.exists(f'result/{task_id}/final.png') or os.path.exists(f'result/{task_id}/final.webp'):
-        # 添加控制台输出提示，避免连续出现命中已翻译的图片时，控制台看起来像是不执行而出现了卡顿。
+        # Add a console output prompt to avoid the console from appearing to be stuck without execution when the translated image is hit consecutively.
         print(f'[succeed] The task {task_id} has exists')
         return web.json_response({'task_id' : task_id, 'status': 'successful'})
     # elif os.path.exists(f'result/{task_id}'):


### PR DESCRIPTION
In actual use, it is found that after a long period of translation, the console will only display 'New run task xxx' continuously without any further output, and no translated pictures will be output under the result. When closing cmd and re-executing the command, everything Back to normal.
After testing, after modifying two places, this problem disappears. One is for an existing translation picture, the console outputs "existing translation picture" to avoid misunderstanding and no response. The other is to add a progress feedback and return True when skipping existing images in manga_translator.py