### PR TITLE
Add support for GPT-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Then you can find the translation result in `result/` directory, e.g. using Ngin
 | deepl      | ✔️      |         | Requires `DEEPL_AUTH_KEY`                              |
 | gpt3       | ✔️      |         | Implements text-davinci-003. Requires `OPENAI_API_KEY` |
 | gpt3.5     | ✔️      |         | Implements gpt-3.5-turbo. Requires `OPENAI_API_KEY`    |
+| gpt4       | ✔️      |         | Implements gpt-4. Requires `OPENAI_API_KEY`            |
 | papago     |         |         |                                                        |
 | offline    |         | ✔️      | Chooses most suitable offline translator for language  |
 | sugoi      |         | ✔️      | Sugoi V4.0 Models (recommended for JPN->ENG)           |
@@ -256,7 +257,7 @@ VIN: Vietnames
 --upscale-ratio {1,2,3,4,8,16,32}            Image upscale ratio applied before detection. Can
                                              improve text detection.
 --colorizer {mc2}                            Colorization model to use.
---translator {google,youdao,baidu,deepl,papago,gpt3,gpt3.5,none,original,offline,nllb,nllb_big,sugoi,jparacrawl,jparacrawl_big,m2m100,m2m100_big}
+--translator {google,youdao,baidu,deepl,papago,gpt3,gpt3.5,gpt4,none,original,offline,nllb,nllb_big,sugoi,jparacrawl,jparacrawl_big,m2m100,m2m100_big}
                                              Language translator to use
 --translator-chain TRANSLATOR_CHAIN          Output of one translator goes in another. Example:
                                              --translator-chain "google:JPN;sugoi:ENG".

--- a/README_CN.md
+++ b/README_CN.md
@@ -63,6 +63,7 @@ $ pip install git+https://github.com/lucasb-eyer/pydensecrf.git
 | deepl          | ✔️      |         | 需要 `DEEPL_AUTH_KEY`                             |
 | gpt3           | ✔️      |         | Implements text-davinci-003. Requires `OPENAI_API_KEY`|
 | gpt3.5         | ✔️      |         | Implements gpt-3.5-turbo. Requires `OPENAI_API_KEY`   |
+| gpt4           | ✔️      |         | Implements gpt-4. Requires `OPENAI_API_KEY`           |
 | papago         |         |         |                                                       |
 | offline        |         | ✔️      |  自动选择可用的离线模型，只是选择器                                                  |
 | sugoi          |         | ✔️      |  只能翻译英文                                                    |
@@ -123,7 +124,7 @@ VIN: Vietnames
 --upscale-ratio {1,2,3,4,8,16,32}            Image upscale ratio applied before detection. Can
                                              improve text detection.
 --colorizer {mc2}                            Colorization model to use.
---translator {google,youdao,baidu,deepl,papago,gpt3,gpt3.5,none,original,offline,nllb,nllb_big,sugoi,jparacrawl,jparacrawl_big,m2m100,m2m100_big}
+--translator {google,youdao,baidu,deepl,papago,gpt3,gpt3.5,gpt4,none,original,offline,nllb,nllb_big,sugoi,jparacrawl,jparacrawl_big,m2m100,m2m100_big}
                                              Language translator to use
 --translator-chain TRANSLATOR_CHAIN          Output of one translator goes in another. Example:
                                              --translator-chain "google:JPN;sugoi:ENG".

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -6,7 +6,7 @@ from .google import GoogleTranslator
 from .youdao import YoudaoTranslator
 from .deepl import DeeplTranslator
 from .papago import PapagoTranslator
-from .chatgpt import GPT3Translator, GPT35TurboTranslator
+from .chatgpt import GPT3Translator, GPT35TurboTranslator, GPT4Translator
 from .nllb import NLLBTranslator, NLLBBigTranslator
 from .sugoi import JparacrawlTranslator, JparacrawlBigTranslator, SugoiTranslator
 from .m2m100 import M2M100Translator, M2M100BigTranslator
@@ -33,6 +33,7 @@ TRANSLATORS = {
     'papago': PapagoTranslator,
     'gpt3': GPT3Translator,
     'gpt3.5': GPT35TurboTranslator,
+    'gpt4': GPT4Translator,
     'none': NoneTranslator,
     'original': OriginalTranslator,
     **OFFLINE_TRANSLATORS,

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -136,11 +136,10 @@ class GPT3Translator(CommonTranslator):
         self.token_count_last = response.usage['total_tokens']
         return response.choices[0].text
 
-class GPTChatTranslator(GPT3Translator):
+class GPT35TurboTranslator(GPT3Translator):
     _MAX_REQUESTS_PER_MINUTE = 200
     PROMPT_TEMPLATE = SIMPLE_PROMPT_TEMPLATE
     _RETRY_ATTEMPTS = 5
-    _model: Literal['gpt-3.5-turbo', 'gpt-4']
 
     async def _request_translation(self, prompt: str) -> str:
         messages = [
@@ -152,7 +151,7 @@ class GPTChatTranslator(GPT3Translator):
         for i in range(self._RETRY_ATTEMPTS):
             try:
                 response = openai.ChatCompletion.create(
-                    model=self._model,
+                    model='gpt-3.5-turbo',
                     messages=messages,
                     max_tokens=2048,
                     temperature=self.temperature,
@@ -174,7 +173,39 @@ class GPTChatTranslator(GPT3Translator):
         # If no response with text is found, return the first response's content (which may be empty)
         return response.choices[0].message.content
 
-class GPT35TurboTranslator(GPTChatTranslator):
-    _model = 'gpt-3.5-turbo'
-class GPT4Translator(GPTChatTranslator):
-    _model = 'gpt-4'
+class GPT4Translator(GPT3Translator):
+    _MAX_REQUESTS_PER_MINUTE = 200
+    PROMPT_TEMPLATE = SIMPLE_PROMPT_TEMPLATE
+    _RETRY_ATTEMPTS = 3
+    async def _request_translation(self, prompt: str) -> str:
+        messages = [
+            {'role': 'system', 'content': 'You are a professional translator who will follow the required format for translation.'},
+            {'role': 'user', 'content': prompt},
+        ]
+
+        # Due to load on OpenAI servers, this fails relatively often.
+        # The openai library does retry, but sometimes it's not enough.
+        for i in range(self._RETRY_ATTEMPTS):
+            try:
+                response = openai.ChatCompletion.create(
+                    model='gpt-4',
+                    messages=messages,
+                    max_tokens=4096,
+                    temperature=self.temperature,
+                )
+                break
+            except:
+                if i == self._RETRY_ATTEMPTS - 1:
+                    raise Exception('Failed to get response from OpenAI servers. Use a different translator or try again later.')
+                self.logger.warn(f'Failed to get response from OpenAI servers. Retrying... Attempt: {i+1}/{self._RETRY_ATTEMPTS}')
+                await asyncio.sleep(1)
+                continue
+
+        self.token_count += response.usage['total_tokens']
+        self.token_count_last = response.usage['total_tokens']
+        for choice in response.choices:
+            if 'text' in choice:
+                return choice.text
+
+        # If no response with text is found, return the first response's content (which may be empty)
+        return response.choices[0].message.content

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -139,7 +139,7 @@ class GPT3Translator(CommonTranslator):
 class GPT35TurboTranslator(GPT3Translator):
     _MAX_REQUESTS_PER_MINUTE = 200
     PROMPT_TEMPLATE = SIMPLE_PROMPT_TEMPLATE
-    _RETRY_ATTEMPTS = 5
+    _RETRY_ATTEMPTS = 3
 
     async def _request_translation(self, prompt: str) -> str:
         messages = [
@@ -147,7 +147,8 @@ class GPT35TurboTranslator(GPT3Translator):
             {'role': 'user', 'content': prompt},
         ]
 
-        # Due to load on OpenAI servers, this fails relatively often, so retry a few times
+        # Due to load on OpenAI servers, this fails relatively often.
+        # The openai library does retry, but sometimes it's not enough.
         for i in range(self._RETRY_ATTEMPTS):
             try:
                 response = openai.ChatCompletion.create(
@@ -177,6 +178,7 @@ class GPT4Translator(GPT3Translator):
     _MAX_REQUESTS_PER_MINUTE = 200
     PROMPT_TEMPLATE = SIMPLE_PROMPT_TEMPLATE
     _RETRY_ATTEMPTS = 3
+
     async def _request_translation(self, prompt: str) -> str:
         messages = [
             {'role': 'system', 'content': 'You are a professional translator who will follow the required format for translation.'},

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -36,7 +36,7 @@ class GPT3Translator(CommonTranslator):
     }
     _INVALID_REPEAT_COUNT = 2 # repeat 2 times at most if invalid translation was returned
     _MAX_REQUESTS_PER_MINUTE = 20
-    _RETRY_ATTEMPTS = 3
+    _RETRY_ATTEMPTS = 3 # Number of times to retry an errored request before giving up
 
     _MAX_TOKENS = 4096
     _prompt_template = SIMPLE_PROMPT_TEMPLATE


### PR DESCRIPTION
I adapted the @thatDudo's code to also work for the GPT-4 model as it has better performance. Do note that it's 15x to 30x more expensive than the gpt-3.5-turbo model, so use with care.

API access to GPT-4 is under closed beta, but I haven't been able to test what happens if you pass an API key with no GPT-4 access. In theory, it should just fail and throw an exception, but maybe someone can take a look at that if deemed necessary.

Finally I also added a "retry" section for both GPT-4 and GPT-3.5, as OpenAI has pretty large server load and just responds with a 500 error sometimes. This won't cost any extra tokens, but should make it more reliable.