### PR TITLE
Add bubble recognition function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ Manga-translated
 .env
 .env.local
 test/testdata/bboxes
+.idea
+pyvenv.cfg
+Scripts
+Lib
+include
+share

--- a/README.md
+++ b/README.md
@@ -328,6 +328,14 @@ VIN: Vietnames
 --ws-url WS_URL                              Server URL for WebSocket mode
 --save-quality SAVE_QUALITY                  Quality of saved JPEG image, range from 0 to 100 with
                                              100 being best
+--ignore-bubble {Numbers from 1 to 50}       The threshold for ignoring text in non bubble areas, with
+                                             valid values ranging from 1 to 50, does not ignore others.
+                                             Recommendation 5 to 10. If it is too small, normal bubble
+                                             areas may be ignored, and if it is too large, non bubble
+                                             areas may be considered normal bubbles
+                                             For example, --ignore-bubble 5
+
+
 ```
 
 <!-- Auto generated end -->

--- a/README_CN.md
+++ b/README_CN.md
@@ -194,6 +194,12 @@ VIN: Vietnames
 --ws-url WS_URL                              Server URL for WebSocket mode
 --save-quality SAVE_QUALITY                  Quality of saved JPEG image, range from 0 to 100 with
                                              100 being best
+--ignore-bubble {Numbers from 1 to 50}       后边的语句都翻译成英文：忽略非气泡区域中的文本块，如果仅仅想对气泡进行处理，
+                                             可启用该参数。范围 从 1 到 50，不在范围内则该参数不起作用。建议 5 到 10。
+                                             如果太小，正常气泡可能会被当做非气泡区，如果太大，则非气泡区可能被当做正常气泡
+                                             例如 --ignore-bubble 5
+
+
 ```
 
 <!-- Auto generated end -->

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -151,6 +151,7 @@ parser.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE', ''), type=str, 
 # parser.add_argument('--log-web', action='store_true', help='Used by web module to decide if web logs should be surfaced')
 parser.add_argument('--ws-url', default='ws://localhost:5000', type=str, help='Server URL for WebSocket mode')
 parser.add_argument('--save-quality', default=100, type=int, help='Quality of saved JPEG image, range from 0 to 100 with 100 being best')
+parser.add_argument('--ignore-bubble', default=0, type=int, help='The threshold for ignoring text in non bubble areas, with valid values ranging from 1 to 50, does not ignore others. Recommendation 5 to 10. If it is too small, normal bubble areas may be ignored, and if it is too large, non bubble areas may be considered normal bubbles')
 
 # Generares dict with a default value for each argument
 DEFAULT_ARGS = vars(parser.parse_args([]))

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -76,6 +76,8 @@ class MangaTranslator():
         self._add_logger_hook()
 
         params = params or {}
+        # Use environment variables to save thresholds for use in ocr
+        os.environ['ignore_bubble']=str(params["ignore_bubble"])
         self.verbose = params.get('verbose', False)
         self.ignore_errors = params.get('ignore_errors', False)
 

--- a/manga_translator/ocr/common.py
+++ b/manga_translator/ocr/common.py
@@ -4,6 +4,8 @@ from typing import List, Union
 from collections import Counter
 import networkx as nx
 import itertools
+import os
+import cv2
 
 from ..utils import InfererModule, TextBlock, ModelWrapper, Quadrilateral
 
@@ -47,6 +49,77 @@ class CommonOCR(InfererModule):
     @abstractmethod
     async def _recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
         pass
+
+    def check_color(self,image):
+        """
+        Determine whether there are colors in non black, gray, white, and other gray areas in an RGB color image。
+        params：
+        image -- np.array
+        return：
+        True -- Colors with non black, gray, white, and other grayscale areas
+        False -- Images are all grayscale areas
+        """
+        gray_image = np.dot(image[...,:3], [0.299, 0.587, 0.114])
+        for i in range(image.shape[0]):
+            for j in range(image.shape[1]):
+                color = image[i, j]
+                color_distance = np.sum((color - gray_image[i, j])**2)
+                if color_distance > 100:
+                    return True
+        return False
+
+    def is_ignore(self,region_img):
+        """
+        Principle: Normally, white bubbles and their text boxes are mostly white, while black bubbles and their text boxes are mostly black. We calculate the ratio of white or black pixels around the text block to the total pixels, and judge whether the area is a normal bubble area or not. Based on the value of the --ingore-bubble parameter, if the ratio is greater than the base value and less than (100-base value), then it is considered a non-bubble area.
+        The normal range for ingore-bubble is 1-50, and other values are considered not input. The recommended value for ingore-bubble is 10. The smaller it is, the more likely it is to recognize normal bubbles as image text and skip them. The larger it is, the more likely it is to recognize image text as normal bubbles.
+
+        Assuming ingore-bubble = 10
+        The text block is surrounded by white if it is <10, and the text block is very likely to be a normal white bubble.
+        The text block is surrounded by black if it is >90, and the text block is very likely to be a normal black bubble.
+        Between 10 and 90, if there are black and white spots around it, the text block is very likely not a normal bubble, but an image.
+
+        The input parameter is the image data of the text block processed by OCR.
+        Calculate the ratio of black or white pixels in the four rectangular areas formed by taking 2 pixels from the edges of the four sides of the image.
+        Return the overall ratio. If it is between basevalue and (100-basevalue), skip it.
+
+        last determine if there is color, consider the colored text as invalid information and skip it without translation
+        """
+        basevalue=int(os.environ['ignore_bubble'])
+        self.logger.info(f"\nignore_bubble:{basevalue}")
+
+        if basevalue<1 or basevalue>50:
+            self.logger.info(f"ignore_bubble not between 1 and 99, no need to handle")
+            return  False
+        # 255 is white, 0 is black
+        _, binary_raw_mask = cv2.threshold(region_img, 127, 255, cv2.THRESH_BINARY)
+        height, width = binary_raw_mask.shape[:2]
+
+        total=0
+        top_sum = sum(binary_raw_mask[0:2, 0:width].ravel() == 0)
+        total+= binary_raw_mask[0:2, 0:width].size
+
+        bottom_sum = sum(binary_raw_mask[height-2:height, 0:width].ravel() == 0)
+        total+= binary_raw_mask[height-2:height, 0:width].size
+
+        left_sum = sum(binary_raw_mask[2:height-2, 0:2].ravel() == 0)
+        total+= binary_raw_mask[2:height-2, 0:2].size
+
+        right_sum = sum(binary_raw_mask[2:height-2, width-2:width].ravel() == 0)
+        total += binary_raw_mask[2:height-2, width-2:width].size
+
+        sum_all=top_sum+bottom_sum+left_sum+right_sum
+        ratio = round( sum_all / total, 6)*100
+        self.logger.info(f"ingore:sum_all={top_sum},total={total},ratio={ratio}")
+        if ratio>=basevalue and ratio<=(100-basevalue):
+            self.logger.info(f"ignore this text block")
+            return True
+        # To determine if there is color, consider the colored text as invalid information and skip it without translation
+        if self.check_color(region_img):
+            self.logger.info(f"ignore Colorful text block")
+            return True
+        self.logger.info(f"normal bubble")
+        return False
+
 
 class OfflineOCR(CommonOCR, ModelWrapper):
     _MODEL_SUB_DIR = 'ocr'

--- a/manga_translator/ocr/model_32px.py
+++ b/manga_translator/ocr/model_32px.py
@@ -71,7 +71,12 @@ class Model32pxOCR(OfflineOCR):
             region = np.zeros((N, text_height, max_width, 3), dtype = np.uint8)
             for i, idx in enumerate(indices):
                 W = region_imgs[idx].shape[1]
-                region[i, :, : W, :] = region_imgs[idx]
+                tmp = region_imgs[idx]
+                # Determine whether to skip the text block, and return True to skip.
+                if  self.is_ignore(region_imgs[idx]):
+                    ix+=1
+                    continue
+                region[i, :, : W, :]=tmp
                 if verbose:
                     os.makedirs('result/ocrs/', exist_ok=True)
                     if quadrilaterals[idx][1] == 'v':

--- a/manga_translator/ocr/model_48px_ctc.py
+++ b/manga_translator/ocr/model_48px_ctc.py
@@ -76,7 +76,12 @@ class Model48pxCTCOCR(OfflineOCR):
             region = np.zeros((N, text_height, max_width, 3), dtype = np.uint8)
             for i, idx in enumerate(indices):
                 W = region_imgs[idx].shape[1]
-                region[i, :, : W, :] = region_imgs[idx]
+                tmp = region_imgs[idx]
+                # Determine whether to skip the text block, and return True to skip.
+                if  self.is_ignore(region_imgs[idx]):
+                    ix+=1
+                    continue
+                region[i, :, : W, :]=tmp
                 if verbose:
                     os.makedirs('result/ocrs/', exist_ok=True)
                     if quadrilaterals[idx][1] == 'v':


### PR DESCRIPTION
Add bubble recognition function, only translate text blocks in the bubble area, and directly ignore text blocks outside the bubble area.
Add a threshold parameter. the threshold for ignoring text in non bubble areas, with valid values ranging from 1 to 50, does not ignore others. Recommendation 5 to 10. If it is too small, normal bubble areas may be ignored, and if it is too large, non bubble areas may be considered normal bubbles   For example, --ignore-bubble 5