### PR TITLE
Add bubble function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ Manga-translated
 .env
 .env.local
 test/testdata/bboxes
+.idea
+pyvenv.cfg
+Scripts
+Lib
+include
+share

--- a/README.md
+++ b/README.md
@@ -328,6 +328,14 @@ VIN: Vietnames
 --ws-url WS_URL                              Server URL for WebSocket mode
 --save-quality SAVE_QUALITY                  Quality of saved JPEG image, range from 0 to 100 with
                                              100 being best
+--ignore-bubble {Numbers from 1 to 50}       The threshold for ignoring text in non bubble areas, with
+                                             valid values ranging from 1 to 50, does not ignore others.
+                                             Recommendation 5 to 10. If it is too small, normal bubble
+                                             areas may be ignored, and if it is too large, non bubble
+                                             areas may be considered normal bubbles
+                                             For example, --ignore-bubble 5
+
+
 ```
 
 <!-- Auto generated end -->

--- a/README_CN.md
+++ b/README_CN.md
@@ -194,7 +194,7 @@ VIN: Vietnames
 --ws-url WS_URL                              Server URL for WebSocket mode
 --save-quality SAVE_QUALITY                  Quality of saved JPEG image, range from 0 to 100 with
                                              100 being best
---ignore-bubble {Numbers from 1 to 50}       后边的语句都翻译成英文：忽略非气泡区域中的文本块，如果仅仅想对气泡进行处理，
+--ignore-bubble {Numbers from 1 to 50}       忽略非气泡区域中的文本块，如果仅仅想对气泡进行处理，
                                              可启用该参数。范围 从 1 到 50，不在范围内则该参数不起作用。建议 5 到 10。
                                              如果太小，正常气泡可能会被当做非气泡区，如果太大，则非气泡区可能被当做正常气泡
                                              例如 --ignore-bubble 5

--- a/README_CN.md
+++ b/README_CN.md
@@ -194,6 +194,12 @@ VIN: Vietnames
 --ws-url WS_URL                              Server URL for WebSocket mode
 --save-quality SAVE_QUALITY                  Quality of saved JPEG image, range from 0 to 100 with
                                              100 being best
+--ignore-bubble {Numbers from 1 to 50}       后边的语句都翻译成英文：忽略非气泡区域中的文本块，如果仅仅想对气泡进行处理，
+                                             可启用该参数。范围 从 1 到 50，不在范围内则该参数不起作用。建议 5 到 10。
+                                             如果太小，正常气泡可能会被当做非气泡区，如果太大，则非气泡区可能被当做正常气泡
+                                             例如 --ignore-bubble 5
+
+
 ```
 
 <!-- Auto generated end -->

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -151,6 +151,7 @@ parser.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE', ''), type=str, 
 # parser.add_argument('--log-web', action='store_true', help='Used by web module to decide if web logs should be surfaced')
 parser.add_argument('--ws-url', default='ws://localhost:5000', type=str, help='Server URL for WebSocket mode')
 parser.add_argument('--save-quality', default=100, type=int, help='Quality of saved JPEG image, range from 0 to 100 with 100 being best')
+parser.add_argument('--ignore-bubble', default=0, type=int, help='The threshold for ignoring text in non bubble areas, with valid values ranging from 1 to 50, does not ignore others. Recommendation 5 to 10. If it is too small, normal bubble areas may be ignored, and if it is too large, non bubble areas may be considered normal bubbles')
 
 # Generares dict with a default value for each argument
 DEFAULT_ARGS = vars(parser.parse_args([]))

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -76,6 +76,8 @@ class MangaTranslator():
         self._add_logger_hook()
 
         params = params or {}
+        # Use environment variables to save thresholds for use in ocr
+        os.environ['ignore_bubble']=str(params["ignore_bubble"])
         self.verbose = params.get('verbose', False)
         self.ignore_errors = params.get('ignore_errors', False)
 

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -77,7 +77,7 @@ class MangaTranslator():
 
         params = params or {}
         # Use environment variables to save thresholds for use in ocr
-        os.environ['ignore_bubble']=str(params["ignore_bubble"])
+        self.ignore_bubble=int(params.get('ignore_bubble', 0))
         self.verbose = params.get('verbose', False)
         self.ignore_errors = params.get('ignore_errors', False)
 
@@ -401,7 +401,7 @@ class MangaTranslator():
                                         self.device, self.verbose)
 
     async def _run_ocr(self, ctx: Context):
-        textlines = await dispatch_ocr(ctx.ocr, ctx.img_rgb, ctx.textlines, self.device, self.verbose)
+        textlines = await dispatch_ocr(ctx.ocr, ctx.img_rgb, ctx.textlines, self.device, self.verbose, self.ignore_bubble)
 
         # Filter out regions by original text
         new_textlines = []
@@ -451,7 +451,7 @@ class MangaTranslator():
         return new_text_regions
 
     async def _run_mask_refinement(self, ctx: Context):
-        return await dispatch_mask_refinement(ctx.text_regions, ctx.img_rgb, ctx.mask_raw, 'fit_text', self.verbose)
+        return await dispatch_mask_refinement(ctx.text_regions, ctx.img_rgb, ctx.mask_raw, 'fit_text', self.verbose,self.ignore_bubble)
 
     async def _run_inpainting(self, ctx: Context):
         return await dispatch_inpainting(ctx.inpainter, ctx.img_rgb, ctx.mask, ctx.inpainting_size, self.using_cuda, self.verbose)

--- a/manga_translator/mask_refinement/__init__.py
+++ b/manga_translator/mask_refinement/__init__.py
@@ -1,14 +1,16 @@
+import os
 from typing import List
 import cv2
 import numpy as np
 # from functools import reduce
 
 from .text_mask_utils import complete_mask_fill, filter_masks, complete_mask
-from ..utils import TextBlock, Quadrilateral
+from ..utils import TextBlock, Quadrilateral, is_ignore
 
 async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mask: np.ndarray, method: str = 'fit_text', verbose: bool = False) -> np.ndarray:
     img_resized = cv2.resize(raw_image, (raw_image.shape[1] // 2, raw_image.shape[0] // 2), interpolation = cv2.INTER_LINEAR)
     mask_resized = cv2.resize(raw_mask, (raw_image.shape[1] // 2, raw_image.shape[0] // 2), interpolation = cv2.INTER_LINEAR)
+
     mask_resized[mask_resized > 0] = 255
     bboxes_resized = []
     for region in text_regions:
@@ -30,4 +32,25 @@ async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mas
         final_mask[final_mask > 0] = 255
     else:
         final_mask = np.zeros((raw_image.shape[0], raw_image.shape[1]), dtype = np.uint8)
+
+    ignore_bubble=int(os.environ['ignore_bubble'])
+
+    if ignore_bubble<1 or ignore_bubble>50:
+        return final_mask
+
+    # bubble
+    kernel_size = int(max(final_mask.shape) * 0.025)  # 选择一个合适的核大小
+    kernel = np.ones((kernel_size, kernel_size), np.uint8)
+    final_mask = cv2.dilate(final_mask, kernel, iterations=1)  # 根据需要调整迭代次数
+    # border
+    contours, _ = cv2.findContours(final_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    for cnt in contours:
+        temp_mask = np.zeros_like(final_mask)
+        # rect min
+        x, y, w, h = cv2.boundingRect(cnt)
+        cv2.rectangle(temp_mask, (x, y), (x + w, y + h), 255, -1)
+        # get textblock
+        textblock=cv2.bitwise_and(raw_image, raw_image, mask=temp_mask)
+        if is_ignore(textblock):
+            cv2.drawContours(final_mask, [cnt], -1, 0, -1)
     return final_mask

--- a/manga_translator/mask_refinement/__init__.py
+++ b/manga_translator/mask_refinement/__init__.py
@@ -5,9 +5,10 @@ import numpy as np
 # from functools import reduce
 
 from .text_mask_utils import complete_mask_fill, filter_masks, complete_mask
-from ..utils import TextBlock, Quadrilateral, is_ignore
+from ..utils import TextBlock, Quadrilateral
+from ..utils.bubble import is_ignore
 
-async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mask: np.ndarray, method: str = 'fit_text', verbose: bool = False) -> np.ndarray:
+async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mask: np.ndarray, method: str = 'fit_text', verbose: bool = False, ignore_bubble: int = 0) -> np.ndarray:
     img_resized = cv2.resize(raw_image, (raw_image.shape[1] // 2, raw_image.shape[0] // 2), interpolation = cv2.INTER_LINEAR)
     mask_resized = cv2.resize(raw_mask, (raw_image.shape[1] // 2, raw_image.shape[0] // 2), interpolation = cv2.INTER_LINEAR)
 
@@ -33,8 +34,6 @@ async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mas
     else:
         final_mask = np.zeros((raw_image.shape[0], raw_image.shape[1]), dtype = np.uint8)
 
-    ignore_bubble=int(os.environ['ignore_bubble'])
-
     if ignore_bubble<1 or ignore_bubble>50:
         return final_mask
 
@@ -51,6 +50,6 @@ async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mas
         cv2.rectangle(temp_mask, (x, y), (x + w, y + h), 255, -1)
         # get textblock
         textblock=cv2.bitwise_and(raw_image, raw_image, mask=temp_mask)
-        if is_ignore(textblock):
+        if is_ignore(textblock, ignore_bubble):
             cv2.drawContours(final_mask, [cnt], -1, 0, -1)
     return final_mask

--- a/manga_translator/ocr/__init__.py
+++ b/manga_translator/ocr/__init__.py
@@ -26,8 +26,8 @@ async def prepare(ocr_key: str, device: str = 'cpu'):
         await ocr.download()
         await ocr.load(device)
 
-async def dispatch(ocr_key: str, image: np.ndarray, regions: List[Quadrilateral], device: str = 'cpu', verbose: bool = False) -> List[Quadrilateral]:
+async def dispatch(ocr_key: str, image: np.ndarray, regions: List[Quadrilateral], device: str = 'cpu', verbose: bool = False,ignore_bubble: int = 0) -> List[Quadrilateral]:
     ocr = get_ocr(ocr_key)
     if isinstance(ocr, OfflineOCR):
         await ocr.load(device)
-    return await ocr.recognize(image, regions, verbose)
+    return await ocr.recognize(image, regions, verbose, ignore_bubble)

--- a/manga_translator/ocr/common.py
+++ b/manga_translator/ocr/common.py
@@ -4,6 +4,8 @@ from typing import List, Union
 from collections import Counter
 import networkx as nx
 import itertools
+import os
+import cv2
 
 from ..utils import InfererModule, TextBlock, ModelWrapper, Quadrilateral
 
@@ -47,6 +49,77 @@ class CommonOCR(InfererModule):
     @abstractmethod
     async def _recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
         pass
+
+    def check_color(self,image):
+        """
+        Determine whether there are colors in non black, gray, white, and other gray areas in an RGB color image。
+        params：
+        image -- np.array
+        return：
+        True -- Colors with non black, gray, white, and other grayscale areas
+        False -- Images are all grayscale areas
+        """
+        gray_image = np.dot(image[...,:3], [0.299, 0.587, 0.114])
+        for i in range(image.shape[0]):
+            for j in range(image.shape[1]):
+                color = image[i, j]
+                color_distance = np.sum((color - gray_image[i, j])**2)
+                if color_distance > 100:
+                    return True
+        return False
+
+    def is_ignore(self,region_img):
+        """
+        Principle: Normally, white bubbles and their text boxes are mostly white, while black bubbles and their text boxes are mostly black. We calculate the ratio of white or black pixels around the text block to the total pixels, and judge whether the area is a normal bubble area or not. Based on the value of the --ingore-bubble parameter, if the ratio is greater than the base value and less than (100-base value), then it is considered a non-bubble area.
+        The normal range for ingore-bubble is 1-50, and other values are considered not input. The recommended value for ingore-bubble is 10. The smaller it is, the more likely it is to recognize normal bubbles as image text and skip them. The larger it is, the more likely it is to recognize image text as normal bubbles.
+
+        Assuming ingore-bubble = 10
+        The text block is surrounded by white if it is <10, and the text block is very likely to be a normal white bubble.
+        The text block is surrounded by black if it is >90, and the text block is very likely to be a normal black bubble.
+        Between 10 and 90, if there are black and white spots around it, the text block is very likely not a normal bubble, but an image.
+
+        The input parameter is the image data of the text block processed by OCR.
+        Calculate the ratio of black or white pixels in the four rectangular areas formed by taking 2 pixels from the edges of the four sides of the image.
+        Return the overall ratio. If it is between basevalue and (100-basevalue), skip it.
+
+        last determine if there is color, consider the colored text as invalid information and skip it without translation
+        """
+        basevalue=int(os.environ['ignore_bubble'])
+        self.logger.info(f"\nignore_bubble:{basevalue}")
+
+        if basevalue<1 or basevalue>50:
+            self.logger.info(f"ignore_bubble not between 1 and 99, no need to handle")
+            return  False
+        # 255 is white, 0 is black
+        _, binary_raw_mask = cv2.threshold(region_img, 127, 255, cv2.THRESH_BINARY)
+        height, width = binary_raw_mask.shape[:2]
+
+        total=0
+        top_sum = sum(binary_raw_mask[0:2, 0:width].ravel() == 0)
+        total+= binary_raw_mask[0:2, 0:width].size
+
+        bottom_sum = sum(binary_raw_mask[height-2:height, 0:width].ravel() == 0)
+        total+= binary_raw_mask[height-2:height, 0:width].size
+
+        left_sum = sum(binary_raw_mask[2:height-2, 0:2].ravel() == 0)
+        total+= binary_raw_mask[2:height-2, 0:2].size
+
+        right_sum = sum(binary_raw_mask[2:height-2, width-2:width].ravel() == 0)
+        total += binary_raw_mask[2:height-2, width-2:width].size
+
+        sum_all=top_sum+bottom_sum+left_sum+right_sum
+        ratio = round( sum_all / total, 6)*100
+        self.logger.info(f"ingore:sum_all={top_sum},total={total},ratio={ratio}")
+        if ratio>=basevalue and ratio<=(100-basevalue):
+            self.logger.info(f"ignore this text block")
+            return True
+        # To determine if there is color, consider the colored text as invalid information and skip it without translation
+        if self.check_color(region_img):
+            self.logger.info(f"ignore Colorful text block")
+            return True
+        self.logger.info(f"normal bubble")
+        return False
+
 
 class OfflineOCR(CommonOCR, ModelWrapper):
     _MODEL_SUB_DIR = 'ocr'

--- a/manga_translator/ocr/common.py
+++ b/manga_translator/ocr/common.py
@@ -37,15 +37,15 @@ class CommonOCR(InfererModule):
                     for node in nodes:
                         yield bboxes[node], majority_dir
 
-    async def recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
+    async def recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False, ignore_bubble: int = 0) -> List[Quadrilateral]:
         '''
         Performs the optical character recognition, using the `textlines` as areas of interests.
         Returns a `textlines` list with the `textline.text` property set to the detected text string.
         '''
-        return await self._recognize(image, textlines, verbose)
+        return await self._recognize(image, textlines, verbose, ignore_bubble)
 
     @abstractmethod
-    async def _recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
+    async def _recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False, ingore_bubble: int = 0) -> List[Quadrilateral]:
         pass
 
 
@@ -56,5 +56,5 @@ class OfflineOCR(CommonOCR, ModelWrapper):
         return await self.infer(*args, **kwargs)
 
     @abstractmethod
-    async def _infer(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
+    async def _infer(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False, ignore_bubble: int = 0) -> List[Quadrilateral]:
         pass

--- a/manga_translator/ocr/common.py
+++ b/manga_translator/ocr/common.py
@@ -4,8 +4,6 @@ from typing import List, Union
 from collections import Counter
 import networkx as nx
 import itertools
-import os
-import cv2
 
 from ..utils import InfererModule, TextBlock, ModelWrapper, Quadrilateral
 
@@ -49,76 +47,6 @@ class CommonOCR(InfererModule):
     @abstractmethod
     async def _recognize(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[Quadrilateral]:
         pass
-
-    def check_color(self,image):
-        """
-        Determine whether there are colors in non black, gray, white, and other gray areas in an RGB color image。
-        params：
-        image -- np.array
-        return：
-        True -- Colors with non black, gray, white, and other grayscale areas
-        False -- Images are all grayscale areas
-        """
-        gray_image = np.dot(image[...,:3], [0.299, 0.587, 0.114])
-        for i in range(image.shape[0]):
-            for j in range(image.shape[1]):
-                color = image[i, j]
-                color_distance = np.sum((color - gray_image[i, j])**2)
-                if color_distance > 100:
-                    return True
-        return False
-
-    def is_ignore(self,region_img):
-        """
-        Principle: Normally, white bubbles and their text boxes are mostly white, while black bubbles and their text boxes are mostly black. We calculate the ratio of white or black pixels around the text block to the total pixels, and judge whether the area is a normal bubble area or not. Based on the value of the --ingore-bubble parameter, if the ratio is greater than the base value and less than (100-base value), then it is considered a non-bubble area.
-        The normal range for ingore-bubble is 1-50, and other values are considered not input. The recommended value for ingore-bubble is 10. The smaller it is, the more likely it is to recognize normal bubbles as image text and skip them. The larger it is, the more likely it is to recognize image text as normal bubbles.
-
-        Assuming ingore-bubble = 10
-        The text block is surrounded by white if it is <10, and the text block is very likely to be a normal white bubble.
-        The text block is surrounded by black if it is >90, and the text block is very likely to be a normal black bubble.
-        Between 10 and 90, if there are black and white spots around it, the text block is very likely not a normal bubble, but an image.
-
-        The input parameter is the image data of the text block processed by OCR.
-        Calculate the ratio of black or white pixels in the four rectangular areas formed by taking 2 pixels from the edges of the four sides of the image.
-        Return the overall ratio. If it is between basevalue and (100-basevalue), skip it.
-
-        last determine if there is color, consider the colored text as invalid information and skip it without translation
-        """
-        basevalue=int(os.environ['ignore_bubble'])
-        self.logger.info(f"\nignore_bubble:{basevalue}")
-
-        if basevalue<1 or basevalue>50:
-            self.logger.info(f"ignore_bubble not between 1 and 99, no need to handle")
-            return  False
-        # 255 is white, 0 is black
-        _, binary_raw_mask = cv2.threshold(region_img, 127, 255, cv2.THRESH_BINARY)
-        height, width = binary_raw_mask.shape[:2]
-
-        total=0
-        top_sum = sum(binary_raw_mask[0:2, 0:width].ravel() == 0)
-        total+= binary_raw_mask[0:2, 0:width].size
-
-        bottom_sum = sum(binary_raw_mask[height-2:height, 0:width].ravel() == 0)
-        total+= binary_raw_mask[height-2:height, 0:width].size
-
-        left_sum = sum(binary_raw_mask[2:height-2, 0:2].ravel() == 0)
-        total+= binary_raw_mask[2:height-2, 0:2].size
-
-        right_sum = sum(binary_raw_mask[2:height-2, width-2:width].ravel() == 0)
-        total += binary_raw_mask[2:height-2, width-2:width].size
-
-        sum_all=top_sum+bottom_sum+left_sum+right_sum
-        ratio = round( sum_all / total, 6)*100
-        self.logger.info(f"ingore:sum_all={top_sum},total={total},ratio={ratio}")
-        if ratio>=basevalue and ratio<=(100-basevalue):
-            self.logger.info(f"ignore this text block")
-            return True
-        # To determine if there is color, consider the colored text as invalid information and skip it without translation
-        if self.check_color(region_img):
-            self.logger.info(f"ignore Colorful text block")
-            return True
-        self.logger.info(f"normal bubble")
-        return False
 
 
 class OfflineOCR(CommonOCR, ModelWrapper):

--- a/manga_translator/ocr/model_32px.py
+++ b/manga_translator/ocr/model_32px.py
@@ -71,7 +71,12 @@ class Model32pxOCR(OfflineOCR):
             region = np.zeros((N, text_height, max_width, 3), dtype = np.uint8)
             for i, idx in enumerate(indices):
                 W = region_imgs[idx].shape[1]
-                region[i, :, : W, :] = region_imgs[idx]
+                tmp = region_imgs[idx]
+                # Determine whether to skip the text block, and return True to skip.
+                if  self.is_ignore(region_imgs[idx]):
+                    ix+=1
+                    continue
+                region[i, :, : W, :]=tmp
                 if verbose:
                     os.makedirs('result/ocrs/', exist_ok=True)
                     if quadrilaterals[idx][1] == 'v':

--- a/manga_translator/ocr/model_32px.py
+++ b/manga_translator/ocr/model_32px.py
@@ -12,7 +12,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .common import OfflineOCR
-from ..utils import TextBlock, Quadrilateral, chunks,is_ignore
+from ..utils import TextBlock, Quadrilateral, chunks
+from ..utils.bubble import is_ignore
 
 class Model32pxOCR(OfflineOCR):
     _MODEL_MAPPING = {
@@ -49,7 +50,7 @@ class Model32pxOCR(OfflineOCR):
     async def _unload(self):
         del self.model
     
-    async def _infer(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False) -> List[TextBlock]:
+    async def _infer(self, image: np.ndarray, textlines: List[Quadrilateral], verbose: bool = False, ignore_bubble: int = 0) -> List[TextBlock]:
         text_height = 32
         max_chunk_size = 16
 
@@ -64,7 +65,6 @@ class Model32pxOCR(OfflineOCR):
             is_quadrilaterals = True
 
         ix = 0
-        ignore_bubble=int(os.environ['ignore_bubble'])
         for indices in chunks(perm, max_chunk_size):
             N = len(indices)
             widths = [region_imgs[i].shape[1] for i in indices]
@@ -74,7 +74,7 @@ class Model32pxOCR(OfflineOCR):
                 W = region_imgs[idx].shape[1]
                 tmp = region_imgs[idx]
                 # Determine whether to skip the text block, and return True to skip.
-                if  ignore_bubble >=1 and ignore_bubble<=50 and  is_ignore(region_imgs[idx]):
+                if ignore_bubble >=1 and ignore_bubble <=50 and is_ignore(region_imgs[idx],ignore_bubble):
                     ix+=1
                     continue
                 region[i, :, : W, :]=tmp

--- a/manga_translator/ocr/model_32px.py
+++ b/manga_translator/ocr/model_32px.py
@@ -12,7 +12,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .common import OfflineOCR
-from ..utils import TextBlock, Quadrilateral, chunks
+from ..utils import TextBlock, Quadrilateral, chunks,is_ignore
 
 class Model32pxOCR(OfflineOCR):
     _MODEL_MAPPING = {
@@ -64,6 +64,7 @@ class Model32pxOCR(OfflineOCR):
             is_quadrilaterals = True
 
         ix = 0
+        ignore_bubble=int(os.environ['ignore_bubble'])
         for indices in chunks(perm, max_chunk_size):
             N = len(indices)
             widths = [region_imgs[i].shape[1] for i in indices]
@@ -73,7 +74,7 @@ class Model32pxOCR(OfflineOCR):
                 W = region_imgs[idx].shape[1]
                 tmp = region_imgs[idx]
                 # Determine whether to skip the text block, and return True to skip.
-                if  self.is_ignore(region_imgs[idx]):
+                if  ignore_bubble >=1 and ignore_bubble<=50 and  is_ignore(region_imgs[idx]):
                     ix+=1
                     continue
                 region[i, :, : W, :]=tmp

--- a/manga_translator/ocr/model_48px_ctc.py
+++ b/manga_translator/ocr/model_48px_ctc.py
@@ -76,7 +76,12 @@ class Model48pxCTCOCR(OfflineOCR):
             region = np.zeros((N, text_height, max_width, 3), dtype = np.uint8)
             for i, idx in enumerate(indices):
                 W = region_imgs[idx].shape[1]
-                region[i, :, : W, :] = region_imgs[idx]
+                tmp = region_imgs[idx]
+                # Determine whether to skip the text block, and return True to skip.
+                if  self.is_ignore(region_imgs[idx]):
+                    ix+=1
+                    continue
+                region[i, :, : W, :]=tmp
                 if verbose:
                     os.makedirs('result/ocrs/', exist_ok=True)
                     if quadrilaterals[idx][1] == 'v':

--- a/manga_translator/ocr/model_48px_ctc.py
+++ b/manga_translator/ocr/model_48px_ctc.py
@@ -11,7 +11,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .common import OfflineOCR
-from ..utils import TextBlock, Quadrilateral, AvgMeter, chunks
+from ..utils import TextBlock, Quadrilateral, AvgMeter, chunks,is_ignore
 
 class Model48pxCTCOCR(OfflineOCR):
     _MODEL_MAPPING = {
@@ -69,6 +69,7 @@ class Model48pxCTCOCR(OfflineOCR):
                 perm = sorted(range(len(region_imgs)), key = lambda x: region_imgs[x].shape[1])
 
         ix = 0
+        ignore_bubble=int(os.environ['ignore_bubble'])
         for indices in chunks(perm, max_chunk_size):
             N = len(indices)
             widths = [region_imgs[i].shape[1] for i in indices]
@@ -78,7 +79,7 @@ class Model48pxCTCOCR(OfflineOCR):
                 W = region_imgs[idx].shape[1]
                 tmp = region_imgs[idx]
                 # Determine whether to skip the text block, and return True to skip.
-                if  self.is_ignore(region_imgs[idx]):
+                if  ignore_bubble >=1 and ignore_bubble<=50 and  is_ignore(region_imgs[idx]):
                     ix+=1
                     continue
                 region[i, :, : W, :]=tmp

--- a/manga_translator/utils/__init__.py
+++ b/manga_translator/utils/__init__.py
@@ -3,3 +3,4 @@ from .log import *
 from .general import *
 from .textblock import *
 from .inference import *
+from .bubble import is_ignore

--- a/manga_translator/utils/bubble.py
+++ b/manga_translator/utils/bubble.py
@@ -1,6 +1,5 @@
 import numpy as np
 import cv2
-import os
 
 def check_color(image):
     """
@@ -24,7 +23,7 @@ def check_color(image):
         return True
     return False
 
-def is_ignore(region_img):
+def is_ignore(region_img,ignore_bubble = 0):
     """
     Principle: Normally, white bubbles and their text boxes are mostly white, while black bubbles and their text boxes are mostly black. We calculate the ratio of white or black pixels around the text block to the total pixels, and judge whether the area is a normal bubble area or not. Based on the value of the --ingore-bubble parameter, if the ratio is greater than the base value and less than (100-base value), then it is considered a non-bubble area.
     The normal range for ingore-bubble is 1-50, and other values are considered not input. The recommended value for ingore-bubble is 10. The smaller it is, the more likely it is to recognize normal bubbles as image text and skip them. The larger it is, the more likely it is to recognize image text as normal bubbles.
@@ -40,11 +39,8 @@ def is_ignore(region_img):
 
     last determine if there is color, consider the colored text as invalid information and skip it without translation
     """
-    ignore_bubble=int(os.environ['ignore_bubble'])
-
     if ignore_bubble<1 or ignore_bubble>50:
         return  False
-
     _, binary_raw_mask = cv2.threshold(region_img, 127, 255, cv2.THRESH_BINARY)
     height, width = binary_raw_mask.shape[:2]
 

--- a/manga_translator/utils/bubble.py
+++ b/manga_translator/utils/bubble.py
@@ -1,0 +1,74 @@
+import numpy as np
+import cv2
+import os
+
+def check_color(image):
+    """
+    Determine whether there are colors in non black, gray, white, and other gray areas in an RGB color image。
+    params：
+    image -- np.array
+    return：
+    True -- Colors with non black, gray, white, and other grayscale areas
+    False -- Images are all grayscale areas
+    """
+    gray_image = np.dot(image[...,:3], [0.299, 0.587, 0.114])
+    n=0
+    for i in range(image.shape[0]):
+        for j in range(image.shape[1]):
+            color = image[i, j]
+            color_distance = np.sum((color - gray_image[i, j])**2)
+            if color_distance > 100:
+                n+=1
+    # gt 10
+    if n>10:
+        return True
+    return False
+
+def is_ignore(region_img):
+    """
+    Principle: Normally, white bubbles and their text boxes are mostly white, while black bubbles and their text boxes are mostly black. We calculate the ratio of white or black pixels around the text block to the total pixels, and judge whether the area is a normal bubble area or not. Based on the value of the --ingore-bubble parameter, if the ratio is greater than the base value and less than (100-base value), then it is considered a non-bubble area.
+    The normal range for ingore-bubble is 1-50, and other values are considered not input. The recommended value for ingore-bubble is 10. The smaller it is, the more likely it is to recognize normal bubbles as image text and skip them. The larger it is, the more likely it is to recognize image text as normal bubbles.
+
+    Assuming ingore-bubble = 10
+    The text block is surrounded by white if it is <10, and the text block is very likely to be a normal white bubble.
+    The text block is surrounded by black if it is >90, and the text block is very likely to be a normal black bubble.
+    Between 10 and 90, if there are black and white spots around it, the text block is very likely not a normal bubble, but an image.
+
+    The input parameter is the image data of the text block processed by OCR.
+    Calculate the ratio of black or white pixels in the four rectangular areas formed by taking 2 pixels from the edges of the four sides of the image.
+    Return the overall ratio. If it is between ignore_bubble and (100-ignore_bubble), skip it.
+
+    last determine if there is color, consider the colored text as invalid information and skip it without translation
+    """
+    ignore_bubble=int(os.environ['ignore_bubble'])
+
+    if ignore_bubble<1 or ignore_bubble>50:
+        return  False
+
+    _, binary_raw_mask = cv2.threshold(region_img, 127, 255, cv2.THRESH_BINARY)
+    height, width = binary_raw_mask.shape[:2]
+
+    total=0
+    val0=0
+
+    val0+= sum(binary_raw_mask[0:2, 0:width].ravel() == 0)
+    total+= binary_raw_mask[0:2, 0:width].size
+
+    val0+= sum(binary_raw_mask[height-2:height, 0:width].ravel() == 0)
+    total+= binary_raw_mask[height-2:height, 0:width].size
+
+    val0+= sum(binary_raw_mask[2:height-2, 0:2].ravel() == 0)
+    total+= binary_raw_mask[2:height-2, 0:2].size
+
+    val0+= sum(binary_raw_mask[2:height-2, width-2:width].ravel() == 0)
+    total += binary_raw_mask[2:height-2, width-2:width].size
+
+    ratio = round( val0 / total, 6)*100
+    # ignore
+    if ratio>=ignore_bubble and ratio<=(100-ignore_bubble):
+        return True
+    # To determine if there is color, consider the colored text as invalid information and skip it without translation
+    if check_color(region_img):
+        return True
+    return False
+


### PR DESCRIPTION
Add bubble recognition function, only translate text blocks in the bubble area, and directly ignore text blocks outside the bubble area.
Add a threshold parameter. the threshold for ignoring text in non bubble areas, with valid values ranging from 1 to 50, does not ignore others. Recommendation 5 to 10. If it is too small, normal bubble areas may be ignored, and if it is too large, non bubble areas may be considered normal bubbles For example, --ignore-bubble 5