### PR TITLE
Gimp rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ Then you can find the translation result in `result/` directory, e.g. using Ngin
 
 </details>
 
+#### Using Gimp for rendering
+
+When setting output format to {`xcf`, `psd`, `pdf`} Gimp will be used to generate the file.
+
+On Windows this assumes Gimp 2.x to be installed to `C:\Users\<Username>\AppData\Local\Programs\Gimp 2`.
+
+The resulting `.xcf` file contains the original image as the lowest layer and it has the inpainting as a separate layer.
+The translated textboxes have their own layers with the original text as the layer name for easy access.
+
+Limitations:
+- Gimp will turn text layers to regular images when saving `.psd` files.
+- Rotated text isn't handled well in Gimp. When editing a rotated textbox it'll also show a popup that it was modified by an outside program.
+- Font family is controlled separately, with the `--gimp-font` argument.
+
 ### Translators Reference
 
 | Name       | API Key | Offline | Note                                                   |
@@ -306,7 +320,7 @@ ARA: Arabic
                                              Destination language
 -v, --verbose                                Print debug info and save intermediate images in result
                                              folder
--f, --format {png,webp,jpg}                  Output format of the translation.
+-f, --format {png,webp,jpg,xcf,psd,pdf}      Output format of the translation.
 --detector {default,ctd,craft,none}          Text detector used for creating a text mask from an
                                              image, DO NOT use craft for manga, it's not designed
                                              for it
@@ -380,6 +394,7 @@ ARA: Arabic
                                              inpainted images, plus copies of the original for
                                              reference
 --font-path FONT_PATH                        Path to font file
+--gimp-font FONT_FAMILY                      Font family to use for gimp rendering.
 --host HOST                                  Used by web module to decide which host to attach to
 --port PORT                                  Used by web module to decide which port to attach to
 --nonce NONCE                                Used by web module as secret for securing internal web

--- a/README_CN.md
+++ b/README_CN.md
@@ -115,7 +115,7 @@ ARA: Arabic
                                              Destination language
 -v, --verbose                                Print debug info and save intermediate images in result
                                              folder
--f, --format {png,webp,jpg}                  Output format of the translation.
+-f, --format {png,webp,jpg,xcf,psd,pdf}      Output format of the translation.
 --detector {default,ctd,craft,none}          Text detector used for creating a text mask from an
                                              image, DO NOT use craft for manga, it's not designed
                                              for it
@@ -189,6 +189,7 @@ ARA: Arabic
                                              inpainted images, plus copies of the original for
                                              reference
 --font-path FONT_PATH                        Path to font file
+--gimp-font FONT_FAMILY                      Font family to use for gimp rendering.
 --host HOST                                  Used by web module to decide which host to attach to
 --port PORT                                  Used by web module to decide which port to attach to
 --nonce NONCE                                Used by web module as secret for securing internal web

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -145,6 +145,7 @@ g.add_argument('--save-text-file', default='', type=str, help='Like --save-text 
 parser.add_argument('--filter-text', default=None, type=str, help='Filter regions by their text with a regex. Example usage: --text-filter ".*badtext.*"')
 parser.add_argument('--prep-manual', action='store_true', help='Prepare for manual typesetting by outputting blank, inpainted images, plus copies of the original for reference')
 parser.add_argument('--font-path', default='', type=file_path, help='Path to font file')
+parser.add_argument('--gimp-font', default='Sans-serif', type=str, help='Font family to use for gimp rendering.')
 parser.add_argument('--host', default='127.0.0.1', type=str, help='Used by web module to decide which host to attach to')
 parser.add_argument('--port', default=5003, type=int, help='Used by web module to decide which port to attach to')
 parser.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE', ''), type=str, help='Used by web module as secret for securing internal web server communication')

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -373,6 +373,8 @@ class MangaTranslator():
         await self._report_progress('inpainting')
         ctx.img_inpainted = await self._run_inpainting(ctx)
 
+        ctx.gimp_mask = np.dstack((ctx.img_inpainted, ctx.mask))
+
         if self.verbose:
             cv2.imwrite(self._result_path('inpainted.png'), cv2.cvtColor(ctx.img_inpainted, cv2.COLOR_RGB2BGR))
 

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -373,7 +373,7 @@ class MangaTranslator():
         await self._report_progress('inpainting')
         ctx.img_inpainted = await self._run_inpainting(ctx)
 
-        ctx.gimp_mask = np.dstack((ctx.img_inpainted, ctx.mask))
+        ctx.gimp_mask = np.dstack((cv2.cvtColor(ctx.img_inpainted, cv2.COLOR_RGB2BGR), ctx.mask))
 
         if self.verbose:
             cv2.imwrite(self._result_path('inpainted.png'), cv2.cvtColor(ctx.img_inpainted, cv2.COLOR_RGB2BGR))

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -95,7 +95,7 @@ def gimp_render(out_file, ctx: Context):
         text_init=text_init,
         text=text,
         extension=extension,
-        save=save_tempaltes[extension].format(out_file=out_file),
+        save=save_tempaltes[extension].format(out_file=out_file.replace('\\', '\\\\')),
         create_mask=(create_mask.format(mask_file=mask_file) if ctx.gimp_mask is not None else ''),
         rename_mask=(rename_mask if ctx.gimp_mask is not None else ''),
     )
@@ -103,7 +103,7 @@ def gimp_render(out_file, ctx: Context):
     executable = 'gimp'
     if platform.system() == 'Windows':
         gimp_dir = os.getenv('LOCALAPPDATA')+'\\Programs\\GIMP 2\\bin\\'
-        executables = glob.glob(gimp_dir+'gimp-2.*.exe')
+        executables = glob.glob(gimp_dir+'gimp-console-2.*.exe')
         if len(executables) == 0:
             print('error: gimp not found in directory:', gimp_dir)
             return

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -57,8 +57,8 @@ script_template = '''
 )'''
 
 def gimp_render(out_file, ctx: Context):
-    input_file = tempfile.NamedTemporaryFile(suffix='.png')
-    mask_file = tempfile.NamedTemporaryFile(suffix='.png')
+    input_file = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+    mask_file = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
 
     extension = out_file.split('.')[-1]
 
@@ -113,3 +113,5 @@ def gimp_render(out_file, ctx: Context):
 
     input_file.close()
     mask_file.close()
+    os.unlink(input_file.name)
+    os.unlink(mask_file.name)

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -8,6 +8,7 @@ import os
 
 from ..utils import Context
 
+# convert alignment/direction to gimp's values
 alignment_to_justification = {'left': 'TEXT-JUSTIFY-LEFT', 'right': 'TEXT-JUSTIFY-RIGHT', 'center': 'TEXT-JUSTIFY-CENTER'}
 direction_to_base_direction = {'h': 'TEXT-DIRECTION-LTR', 'v': 'TEXT-DIRECTION-TTB-LTR-UPRIGHT', 'hr': 'TEXT-DIRECTION-RTL', 'vr': 'TEXT-DIRECTION-TTB-RTL-UPRIGHT'}
 
@@ -61,6 +62,9 @@ def gimp_render(out_file, ctx: Context):
     extension = out_file.split('.')[-1]
 
     ctx.upscaled.save(input_file)
+    
+    # If there is no text on the page, gimp_mask will be None and there is no
+    # need to add it as a layer.
     if ctx.gimp_mask is not None:
         cv2.imwrite(mask_file, ctx.gimp_mask)
     else:
@@ -81,6 +85,7 @@ def gimp_render(out_file, ctx: Context):
             size=str(text_region.xywh[2])+' '+str(text_region.xywh[3]),
             justify=alignment_to_justification[text_region.alignment],
             font=font_template.format(n=n, font=text_region.font_family) if text_region.font_family != '' else '',
+            # rotated text is weird in gimp so we don't do it unless it's over 10 degrees
             angle=angle_template.format(n=n, angle=math.radians(text_region.angle)) if abs(text_region.angle) > 10 else '',
             language=text_region.target_lang,
             line_spacing=text_region.line_spacing,
@@ -88,6 +93,7 @@ def gimp_render(out_file, ctx: Context):
             base_direction=direction_to_base_direction[text_region.direction],
         ) for n, text_region in enumerate(ctx.text_regions)])
 
+    # scheme script to be ran by gimp
     full_script = script_template.format(
         input_file=input_file.replace('\\', '\\\\'),
         text_init=text_init,
@@ -106,7 +112,7 @@ def gimp_render(out_file, ctx: Context):
             print('error: gimp not found in directory:', gimp_dir)
             return
         executable = executables[0]
-    
+
     subprocess.run([executable, '-i', '-b', full_script])
 
     os.unlink(input_file)

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -91,12 +91,12 @@ def gimp_render(out_file, ctx: Context):
         ) for n, text_region in enumerate(ctx.text_regions)])
 
     full_script = script_template.format(
-        input_file=input_file,
+        input_file=input_file.replace('\\', '\\\\'),
         text_init=text_init,
         text=text,
         extension=extension,
         save=save_tempaltes[extension].format(out_file=out_file.replace('\\', '\\\\')),
-        create_mask=(create_mask.format(mask_file=mask_file) if ctx.gimp_mask is not None else ''),
+        create_mask=(create_mask.format(mask_file=mask_file.replace('\\', '\\\\')) if ctx.gimp_mask is not None else ''),
         rename_mask=(rename_mask if ctx.gimp_mask is not None else ''),
     )
 

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -101,7 +101,7 @@ def gimp_render(out_file, ctx: Context):
     )
 
     executable = 'gimp'
-    if platform.system == 'Windows':
+    if platform.system() == 'Windows':
         gimp_dir = os.getenv('LOCALAPPDATA')+'\\Programs\\GIMP 2\\bin\\'
         executables = glob.glob(gimp_dir+'gimp-2.*.exe')
         if len(executables) == 0:

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -1,0 +1,76 @@
+import tempfile
+import subprocess
+import math
+import cv2
+
+from ..utils import Context
+
+alignment_to_justification = {'left': 'TEXT-JUSTIFY-LEFT', 'right': 'TEXT-JUSTIFY-RIGHT', 'center': 'TEXT-JUSTIFY-CENTER'}
+
+text_init_template = '''
+            ( text{n} ( car ( gimp-text-layer-new image "{text}" "Noto Sans" {text_size} 0 ) ) )
+'''
+
+# text rotation was buggy so I left it out
+#    ( gimp-item-transform-rotate text{n} {angle} TRUE 0 0 )
+
+text_template = '''
+    ( gimp-image-add-layer image text{n} 0 )
+    ( gimp-text-layer-set-color text{n} (list {color}) )
+    ( gimp-item-set-name text{n} "{name}" )
+    ( gimp-layer-set-offsets text{n} {position} )
+    ( gimp-text-layer-resize text{n} {size} )
+    ( gimp-text-layer-set-justification text{n} {justify} )
+'''
+
+save_tempaltes = {
+    'xcf': '( gimp-xcf-save RUN-NONINTERACTIVE image inpainting "{out_file}" "{out_file}" )',
+    'psd': '( file-psd-save RUN-NONINTERACTIVE image inpainting "{out_file}" "{out_file}" 0 0 )',
+    'pdf': '( file-pdf-save RUN-NONINTERACTIVE image inpainting "{out_file}" "{out_file}" TRUE TRUE TRUE )',
+}
+
+script_template = '''
+( let* (
+            ( image ( car ( gimp-file-load RUN-NONINTERACTIVE "{input_file}" "{input_file}" ) ) )
+            ( layer-list (gimp-image-get-layers image))
+            ( background_layer (car layer-list))
+            ( inpainting ( car ( gimp-file-load-layer RUN-NONINTERACTIVE image "{mask_file}" ) ) )
+            {text_init}
+        )
+    ( gimp-image-add-layer image inpainting 0 )
+    ( gimp-item-set-name inpainting "mask" )
+    ( gimp-item-set-name background_layer "original image" )
+    {text}
+    {save}
+    ( gimp-quit 0 )                        
+)'''
+
+def gimp_render(out_file, ctx: Context):
+    input_file = tempfile.NamedTemporaryFile(suffix='.png')
+    mask_file = tempfile.NamedTemporaryFile(suffix='.png')
+
+    ctx.input.save(input_file.name)
+    cv2.imwrite(mask_file.name, ctx.gimp_mask)
+
+    extension = out_file.split('.')[-1]
+
+    text_init = ''.join([text_init_template.format(
+        text=text_region.translation.replace('"', '\\"'), text_size=text_region.font_size, n=n
+        ) for n, text_region in enumerate(ctx.text_regions)])
+
+    text = ''.join([text_template.format(
+        n=n, color=' '.join([str(value) for value in text_region.fg_colors]),
+        name=' '.join(text_region.text), position=str(text_region.xywh[0])+' '+str(text_region.xywh[1]),
+        size=str(text_region.xywh[2])+' '+str(text_region.xywh[3]),
+        justify=alignment_to_justification[text_region.alignment],
+        angle=math.radians(text_region.angle),
+        ) for n, text_region in enumerate(ctx.text_regions)])
+
+    full_script = script_template.format(
+        input_file=input_file.name, mask_file=mask_file.name, text_init=text_init, text=text,
+        extension=extension, save=save_tempaltes[extension].format(out_file=out_file)
+    )
+
+    subprocess.run(['gimp', '-i', '-b', full_script])
+    input_file.close()
+    mask_file.close()

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -57,8 +57,8 @@ script_template = '''
 )'''
 
 def gimp_render(out_file, ctx: Context):
-    input_file = '.gimp_input.png'
-    mask_file = '.gimp_mask.png'
+    input_file = os.path.join(tempfile.gettempdir(), '.gimp_input.png')
+    mask_file = os.path.join(tempfile.gettempdir(), '.gimp_mask.png')
 
     extension = out_file.split('.')[-1]
 

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -8,8 +8,6 @@ import os
 
 from ..utils import Context
 
-DEFAULT_FONT = 'Sans-serif'
-
 alignment_to_justification = {'left': 'TEXT-JUSTIFY-LEFT', 'right': 'TEXT-JUSTIFY-RIGHT', 'center': 'TEXT-JUSTIFY-CENTER'}
 direction_to_base_direction = {'h': 'TEXT-DIRECTION-LTR', 'v': 'TEXT-DIRECTION-TTB-LTR-UPRIGHT', 'hr': 'TEXT-DIRECTION-RTL', 'vr': 'TEXT-DIRECTION-TTB-RTL-UPRIGHT'}
 
@@ -72,7 +70,7 @@ def gimp_render(out_file, ctx: Context):
             n=n,
             text=text_region.translation.replace('"', '\\"'),
             text_size=text_region.font_size,
-            default_font=DEFAULT_FONT+(' Bold' if text_region.bold else '')+(' Italic' if text_region.italic else '')
+            default_font=ctx.gimp_font+(' Bold' if text_region.bold else '')+(' Italic' if text_region.italic else '')
         ) for n, text_region in enumerate(ctx.text_regions)])
 
     text = ''.join([text_template.format(

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -62,7 +62,7 @@ def gimp_render(out_file, ctx: Context):
 
     extension = out_file.split('.')[-1]
 
-    ctx.input.save(input_file)
+    ctx.upscaled.save(input_file)
     if ctx.gimp_mask is not None:
         cv2.imwrite(mask_file, ctx.gimp_mask)
     else:

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -2,6 +2,9 @@ import tempfile
 import subprocess
 import math
 import cv2
+import platform
+import glob
+import os
 
 from ..utils import Context
 
@@ -97,7 +100,16 @@ def gimp_render(out_file, ctx: Context):
         rename_mask=(rename_mask if ctx.gimp_mask is not None else ''),
     )
 
-    subprocess.run(['gimp', '-i', '-b', full_script])
+    executable = 'gimp'
+    if platform.system == 'Windows':
+        gimp_dir = os.getenv('LOCALAPPDATA')+'\\Programs\\GIMP 2\\bin\\'
+        executables = glob.glob(gimp_dir+'gimp-2.*.exe')
+        if len(executables) == 0:
+            print('error: gimp not found in directory:', gimp_dir)
+            return
+        executable = executables[0]
+    
+    subprocess.run([executable, '-i', '-b', full_script])
 
     input_file.close()
     mask_file.close()

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -83,7 +83,7 @@ def gimp_render(out_file, ctx: Context):
             size=str(text_region.xywh[2])+' '+str(text_region.xywh[3]),
             justify=alignment_to_justification[text_region.alignment],
             font=font_template.format(n=n, font=text_region.font_family) if text_region.font_family != '' else '',
-            angle=angle_template.formt(n=n, angle=math.radians(text_region.angle)) if abs(text_region.angle) > 10 else '',
+            angle=angle_template.format(n=n, angle=math.radians(text_region.angle)) if abs(text_region.angle) > 10 else '',
             language=text_region.target_lang,
             line_spacing=text_region.line_spacing,
             letter_spacing=text_region.letter_spacing,

--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -57,14 +57,14 @@ script_template = '''
 )'''
 
 def gimp_render(out_file, ctx: Context):
-    input_file = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
-    mask_file = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+    input_file = '.gimp_input.png'
+    mask_file = '.gimp_mask.png'
 
     extension = out_file.split('.')[-1]
 
-    ctx.input.save(input_file.name)
+    ctx.input.save(input_file)
     if ctx.gimp_mask is not None:
-        cv2.imwrite(mask_file.name, ctx.gimp_mask)
+        cv2.imwrite(mask_file, ctx.gimp_mask)
     else:
         ctx.text_regions = []
 
@@ -91,12 +91,12 @@ def gimp_render(out_file, ctx: Context):
         ) for n, text_region in enumerate(ctx.text_regions)])
 
     full_script = script_template.format(
-        input_file=input_file.name,
+        input_file=input_file,
         text_init=text_init,
         text=text,
         extension=extension,
         save=save_tempaltes[extension].format(out_file=out_file),
-        create_mask=(create_mask.format(mask_file=mask_file.name) if ctx.gimp_mask is not None else ''),
+        create_mask=(create_mask.format(mask_file=mask_file) if ctx.gimp_mask is not None else ''),
         rename_mask=(rename_mask if ctx.gimp_mask is not None else ''),
     )
 
@@ -111,7 +111,5 @@ def gimp_render(out_file, ctx: Context):
     
     subprocess.run([executable, '-i', '-b', full_script])
 
-    input_file.close()
-    mask_file.close()
-    os.unlink(input_file.name)
-    os.unlink(mask_file.name)
+    os.unlink(input_file)
+    os.unlink(mask_file)

--- a/manga_translator/save.py
+++ b/manga_translator/save.py
@@ -1,6 +1,7 @@
 import os
 from PIL import Image
 from abc import abstractmethod
+from .rendering.gimp_render import gimp_render
 
 from .utils import Context
 
@@ -57,6 +58,12 @@ class JPGFormat(ExportFormat):
         result = result.convert('RGB')
         # Certain versions of PIL only support JPEG but not JPG
         result.save(dest, quality=ctx.save_quality, format='JPEG')
+
+class GIMPFormat(ExportFormat):
+    SUPPORTED_FORMATS = ['xcf', 'psd', 'pdf']
+
+    def _save(self, result: Image.Image, dest: str, ctx: Context):
+        gimp_render(dest, ctx)
 
 # class KraFormat(ExportFormat):
 #     SUPPORTED_FORMATS = ['kra']


### PR DESCRIPTION
This PR adds support for saving to new formats using Gimp. This is useful if you want to make modifications to the translation/in-painting. Kind of like with Balloon Translator.

### Description of the feature

It calls the gimp executable (gimp-console on windows) and passes a scheme script that was generated on the fly. This script can be used to automate Gimp headlessly.

This can be used to generate xcf, psd and pdf files, but xcf is the most useful, as psd text layers get turned into images and with pdf the in-painting layer is buggy. I suggest this way of pdf rendering to be removed once a better way comes along as discussed in: #395 

The .xcf file contains the original image as the lowest layer and it has the inpainting as a separate layer. On top of them are the translated textboxes, which have their own layers with the original text as the layer name for easy access.

### Changes to the code

I tried to implement this with minimal changes to the main codebase. Most of the logic is in `manga_translator/rendering/gimp_render.py`.

I added the `gimp_mask` variable to the context to save the parts of the inpainted image that are covered by the mask.

A new cli arg is added: `--gimp-font` can set the font family used by gimp.

Two temporary files are created: for the inpainting and the original image. Their paths are used in the scheme script.

### Needs further attention

I tested this on my Linux and Windows install, but not on Mac OS.

As for language support, I tested translating to English, but I could not test Chinese thoroughly enough as I don't speak the language. It did generate vertical text, but I am unsure if the rtl/ltr orientation is correct.

Similarly, I updated the English readme with a paragraph about this feature, but I could not do the same with the Chinese readme.