### PR TITLE
为gpt3translator添加openai_api_base，使用api_for_open_llm来使用开源llm，如chatglm，千问，百川

### DIFF
--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -6,7 +6,7 @@ import time
 from typing import List, Dict
 
 from .common import CommonTranslator, MissingAPIKeyException
-from .keys import OPENAI_API_KEY, OPENAI_HTTP_PROXY
+from .keys import OPENAI_API_KEY, OPENAI_HTTP_PROXY, OPENAI_API_BASE
 
 CONFIG = None
 
@@ -53,6 +53,7 @@ class GPT3Translator(CommonTranslator):
     def __init__(self):
         super().__init__()
         openai.api_key = openai.api_key or OPENAI_API_KEY
+        openai.api_base = OPENAI_API_BASE
         if not openai.api_key:
             raise MissingAPIKeyException('Please set the OPENAI_API_KEY environment variable before using the chatgpt translator.')
         if OPENAI_HTTP_PROXY:

--- a/manga_translator/translators/keys.py
+++ b/manga_translator/translators/keys.py
@@ -11,5 +11,6 @@ DEEPL_AUTH_KEY = os.getenv('DEEPL_AUTH_KEY', 'ff0adcf6-f119-6fcf-d084-d51a2df9aa
 # openai
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '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')
 OPENAI_HTTP_PROXY = os.getenv('OPENAI_HTTP_PROXY') # TODO: Replace with --proxy
+OPENAI_API_BASE = os.getenv('OPENAI_API_BASE', 'http://api.openai.com/v1')
 
 CAIYUN_TOKEN = ''

--- a/manga_translator/translators/keys.py
+++ b/manga_translator/translators/keys.py
@@ -11,6 +11,6 @@ DEEPL_AUTH_KEY = os.getenv('DEEPL_AUTH_KEY', 'ff0adcf6-f119-6fcf-d084-d51a2df9aa
 # openai
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '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')
 OPENAI_HTTP_PROXY = os.getenv('OPENAI_HTTP_PROXY') # TODO: Replace with --proxy
-OPENAI_API_BASE = os.getenv('OPENAI_API_BASE', 'http://api.openai.com/v1')
+OPENAI_API_BASE = os.getenv('OPENAI_API_BASE', 'https://api.openai.com/v1') #使用api-for-open-llm例子 http://127.0.0.1:8000/v1
 
 CAIYUN_TOKEN = ''


### PR DESCRIPTION
使用https://github.com/xusenlinzy/api-for-open-llm 可以将ChatGLM, LLaMA, LLaMA-2, BLOOM, Falcon, Baichuan, Qwen, Xverse, SqlCoder, CodeLLaMA 等开源大模型统一为openai的后端接口，不用额外创建translator，使用gpt35即可。
具体用法为开启api-for-open-llm，修改translator/key.py中的OPENAI_API_BASE字段，比如：http://127.0.0.1:8001/v1
注意结尾要加"/v1"