### PR TITLE
New Lama inpainting model finetuned on larger datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ THA: Thai
                                              image, DO NOT use craft for manga, it's not designed
                                              for it
 --ocr {32px,48px_ctc}                        Optical character recognition (OCR) model to use
---inpainter {default,lama_mpe,sd,none,original}
+--inpainter {default,lama_large,lama_mpe,sd,none,original}
                                              Inpainting model to use
 --upscaler {waifu2x,esrgan,4xultrasharp}     Upscaler to use. --upscale-ratio has to be set for it
                                              to take effect

--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ THA: Thai
 --min-text-length MIN_TEXT_LENGTH            Minimum text length of a text region
 --inpainting-size INPAINTING_SIZE            Size of image used for inpainting (too large will
                                              result in OOM)
+--inpainting-precision INPAINTING_PRECISION  Inpainting precision for lama, 
+                                             use bf16 while you can.
 --colorization-size COLORIZATION_SIZE        Size of image used for colorization. Set to -1 to use
                                              full image size
 --denoise-sigma DENOISE_SIGMA                Used by colorizer and affects color strength, range

--- a/README_CN.md
+++ b/README_CN.md
@@ -165,6 +165,8 @@ THA: Thai
 --min-text-length MIN_TEXT_LENGTH            Minimum text length of a text region
 --inpainting-size INPAINTING_SIZE            Size of image used for inpainting (too large will
                                              result in OOM)
+--inpainting-precision INPAINTING_PRECISION  Inpainting precision for lama, 
+                                             use bf16 while you can.
 --colorization-size COLORIZATION_SIZE        Size of image used for colorization. Set to -1 to use
                                              full image size
 --denoise-sigma DENOISE_SIGMA                Used by colorizer and affects color strength, range

--- a/README_CN.md
+++ b/README_CN.md
@@ -131,7 +131,7 @@ THA: Thai
                                              image, DO NOT use craft for manga, it's not designed
                                              for it
 --ocr {32px,48px_ctc}                        Optical character recognition (OCR) model to use
---inpainter {default,lama_mpe,sd,none,original}
+--inpainter {default,lama_large,lama_mpe,sd,none,original}
                                              Inpainting model to use
 --upscaler {waifu2x,esrgan,4xultrasharp}     Upscaler to use. --upscale-ratio has to be set for it
                                              to take effect

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -105,7 +105,7 @@ g.add_argument('--use-cuda-limited', action='store_true', help='Turn on/off cuda
 
 parser.add_argument('--detector', default='default', type=str, choices=DETECTORS, help='Text detector used for creating a text mask from an image, DO NOT use craft for manga, it\'s not designed for it')
 parser.add_argument('--ocr', default='48px_ctc', type=str, choices=OCRS, help='Optical character recognition (OCR) model to use')
-parser.add_argument('--inpainter', default='lama_mpe', type=str, choices=INPAINTERS, help='Inpainting model to use')
+parser.add_argument('--inpainter', default='lama_large', type=str, choices=INPAINTERS, help='Inpainting model to use')
 parser.add_argument('--upscaler', default='esrgan', type=str, choices=UPSCALERS, help='Upscaler to use. --upscale-ratio has to be set for it to take effect')
 parser.add_argument('--upscale-ratio', default=None, type=float, help='Image upscale ratio applied before detection. Can improve text detection.')
 parser.add_argument('--colorizer', default=None, type=str, choices=COLORIZERS, help='Colorization model to use.')
@@ -126,6 +126,7 @@ parser.add_argument('--box-threshold', default=0.7, type=float, help='Threshold 
 parser.add_argument('--text-threshold', default=0.5, type=float, help='Threshold for text detection')
 parser.add_argument('--min-text-length', default=0, type=int, help='Minimum text length of a text region')
 parser.add_argument('--inpainting-size', default=2048, type=int, help='Size of image used for inpainting (too large will result in OOM)')
+parser.add_argument('--inpainting-precision', default='fp32', type=str, help='Inpainting precision for lama, use bf16 while you can.', choices=['fp32', 'fp16', 'bf16'])
 parser.add_argument('--colorization-size', default=576, type=int, help='Size of image used for colorization. Set to -1 to use full image size')
 parser.add_argument('--denoise-sigma', default=30, type=int, help='Used by colorizer and affects color strength, range from 0 to 255 (default 30). -1 turns it off.')
 parser.add_argument('--mask-dilation-offset', default=0, type=int, help='By how much to extend the text mask to remove left-over text pixels of the original image.')

--- a/manga_translator/inpainting/__init__.py
+++ b/manga_translator/inpainting/__init__.py
@@ -2,13 +2,14 @@ import numpy as np
 
 from .common import CommonInpainter, OfflineInpainter
 from .inpainting_aot import AotInpainter
-from .inpainting_lama_mpe import LamaMPEInpainter
+from .inpainting_lama_mpe import LamaMPEInpainter, LamaLargeInpainter
 from .inpainting_sd import StableDiffusionInpainter
 from .none import NoneInpainter
 from .original import OriginalInpainter
 
 INPAINTERS = {
     'default': AotInpainter,
+    'lama_large': LamaLargeInpainter,
     'lama_mpe': LamaMPEInpainter,
     'sd': StableDiffusionInpainter,
     'none': NoneInpainter,

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -108,6 +108,8 @@ class MangaTranslator():
         if params.get('model_dir'):
             ModelWrapper._MODEL_DIR = params.get('model_dir')
 
+        os.environ['INPAINTING_PRECISION'] = params.get('inpainting_precision', 'fp32')
+
     @property
     def using_cuda(self):
         return self.device.startswith('cuda')


### PR DESCRIPTION
New lama inpainter (big-lama) finetuned on 512x512 mixture of  300k manga and anime-style images, it performs much better on manga with screentone.  
Also added bfloat16 inference for it, as it was finetuning with bf16 mixed precision, however, fp16 sometimes produces total black results when target resolution is high, I think it overflows somewhere performing fft.  