### PR TITLE
MBART 50 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Limitations:
 | sugoi      |         | ✔️      | Sugoi V4.0 Models (recommended for JPN->ENG)           |
 | m2m100     |         | ✔️      | Supports every language                                |
 | m2m100_big |         | ✔️      |                                                        |
+| mbart50    |         | ✔️      |                                                        |
 | none       |         | ✔️      | Translate to empty texts                               |
 | original   |         | ✔️      | Keep original texts                                    |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -71,6 +71,7 @@ $ pip install git+https://github.com/kodalli/pydensecrf.git
 | m2m100         |         | ✔️      |  可以翻译所有语言                                                     |
 | m2m100_big     |         | ✔️      |  带big的是完整尺寸，不带是精简版                                                    |
 | none           |         | ✔️      | 翻译成空白文本                                          |
+| mbart50    |         | ✔️      |                                                        |
 | original       |         | ✔️      | 翻译成源文本                                            |
 
 ### 语言代码列表

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -11,6 +11,7 @@ from .chatgpt import GPT3Translator, GPT35TurboTranslator, GPT4Translator
 from .nllb import NLLBTranslator, NLLBBigTranslator
 from .sugoi import JparacrawlTranslator, JparacrawlBigTranslator, SugoiTranslator
 from .m2m100 import M2M100Translator, M2M100BigTranslator
+from .mbart50 import MBart50Translator
 from .selective import SelectiveOfflineTranslator, prepare as prepare_selective_translator
 from .none import NoneTranslator
 from .original import OriginalTranslator
@@ -24,6 +25,7 @@ OFFLINE_TRANSLATORS = {
     'jparacrawl_big': JparacrawlBigTranslator,
     'm2m100': M2M100Translator,
     'm2m100_big': M2M100BigTranslator,
+    'mbart50': MBart50Translator,
 }
 
 TRANSLATORS = {

--- a/manga_translator/translators/mbart50.py
+++ b/manga_translator/translators/mbart50.py
@@ -1,0 +1,124 @@
+import os
+import py3langid as langid
+
+
+from .common import OfflineTranslator
+
+ISO_639_1_TO_MBart50 = {
+    'ara': 'ar_AR',
+    'deu': 'de_DE',
+    'eng': 'en_XX',
+    'spa': 'es_XX',
+    'fra': 'fr_XX',
+    'hin': 'hi_IN',
+    'ita': 'it_IT',
+    'jpn': 'ja_XX',
+    'nld': 'nl_XX',
+    'pol': 'pl_PL',
+    'por': 'pt_XX',
+    'rus': 'ru_RU',
+    'swa': 'sw_KE',
+    'tha': 'th_TH',
+    'tur': 'tr_TR',
+    'urd': 'ur_PK',
+    'vie': 'vi_VN',
+    'zho': 'zh_CN',
+    
+}
+
+class MBart50Translator(OfflineTranslator):
+    # https://huggingface.co/facebook/mbart-large-50
+    # other languages can be added as well
+    _LANGUAGE_CODE_MAP = {
+        "ARA": "ar_AR",
+        "DEU": "de_DE",
+        "ENG": "en_XX",
+        "ESP": "es_XX",
+        "FRA": "fr_XX",
+        "HIN": "hi_IN",
+        "ITA": "it_IT",
+        "JPN": "ja_XX",
+        "NLD": "nl_XX",
+        "PLK": "pl_PL",
+        "PTB": "pt_XX",
+        "RUS": "ru_RU",
+        "SWA": "sw_KE",
+        "THA": "th_TH",
+        "TRK": "tr_TR",
+        "URD": "ur_PK",
+        "VIN": "vi_VN",
+        "CHS": "zh_CN",
+    }
+    
+    _MODEL_SUB_DIR = os.path.join(OfflineTranslator._MODEL_DIR, OfflineTranslator._MODEL_SUB_DIR, 'mbart50')
+    
+    _TRANSLATOR_MODEL = "facebook/mbart-large-50-many-to-many-mmt"
+
+
+
+    async def _load(self, from_lang: str, to_lang: str, device: str):
+        from transformers import (
+            MBartForConditionalGeneration,
+            AutoTokenizer,
+        )
+        if ':' not in device:
+            device += ':0'
+        self.device = device
+        self.model = MBartForConditionalGeneration.from_pretrained(self._TRANSLATOR_MODEL)
+        self.tokenizer = AutoTokenizer.from_pretrained(self._TRANSLATOR_MODEL)
+
+    async def _unload(self):
+        del self.model
+        del self.tokenizer
+
+    async def _infer(self, from_lang: str, to_lang: str, queries: list[str]) -> list[str]:
+        if from_lang == 'auto':
+            detected_lang = langid.classify('\n'.join(queries))[0]
+            target_lang = self._map_detected_lang_to_translator(detected_lang)
+
+            if target_lang == None:
+                self.logger.warn('Could not detect language from over all sentence. Will try per sentence.')
+            else:
+                from_lang = target_lang
+
+        return [self._translate_sentence(from_lang, to_lang, query) for query in queries]
+
+    def _translate_sentence(self, from_lang: str, to_lang: str, query: str) -> str:
+        from transformers import pipeline
+
+        if not self.is_loaded():
+            return ''
+
+        if from_lang == 'auto':
+            detected_lang = langid.classify(query)[0]
+            from_lang = self._map_detected_lang_to_translator(detected_lang)
+
+        if from_lang == None:
+            self.logger.warn(f'MBart50 Translation Failed. Could not detect language (Or language not supported for text: {query})')
+            return ''
+
+        translator = pipeline('translation',
+            device=self.device,
+            model=self.model,
+            tokenizer=self.tokenizer,
+            src_lang=from_lang,
+            tgt_lang=to_lang,
+            max_length = 512,
+        )
+
+        result = translator(query)[0]['translation_text']
+        return result
+
+    def _map_detected_lang_to_translator(self, lang):
+        if lang not in ISO_639_1_TO_MBart50:
+            return None
+
+        return ISO_639_1_TO_MBart50[lang]
+
+    async def _download(self):
+        import huggingface_hub
+        huggingface_hub.snapshot_download(self._TRANSLATOR_MODEL, cache_dir=self._MODEL_SUB_DIR)
+
+    def _check_downloaded(self) -> bool:
+        import huggingface_hub
+        return huggingface_hub.try_to_load_from_cache(self._TRANSLATOR_MODEL, 'pytorch_model.bin', cache_dir=self._MODEL_SUB_DIR) is not None

--- a/manga_translator/translators/mbart50.py
+++ b/manga_translator/translators/mbart50.py
@@ -96,8 +96,7 @@ class MBart50Translator(OfflineTranslator):
         if from_lang == 'auto':
             detected_lang = langid.classify(query)[0]
             from_lang = self._map_detected_lang_to_translator(detected_lang)
-        else:
-            from_lang = self._LANGUAGE_CODE_MAP(from_lang)
+
         if from_lang == None:
             self.logger.warn(f'MBart50 Translation Failed. Could not detect language (Or language not supported for text: {query})')
             return ''

--- a/manga_translator/translators/mbart50.py
+++ b/manga_translator/translators/mbart50.py
@@ -69,6 +69,7 @@ class MBart50Translator(OfflineTranslator):
         self.model = MBartForConditionalGeneration.from_pretrained(self._TRANSLATOR_MODEL)
         if self.device != 'cpu':
             self.model.to(self.device)
+        self.model.eval()
         self.tokenizer = AutoTokenizer.from_pretrained(self._TRANSLATOR_MODEL)
 
     async def _unload(self):

--- a/manga_translator/translators/nllb.py
+++ b/manga_translator/translators/nllb.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 import py3langid as langid
 
@@ -57,6 +58,7 @@ class NLLBTranslator(OfflineTranslator):
         'THA': 'tha_Thai',
         'IND': 'ind_Latn'
     }
+    _MODEL_SUB_DIR = os.path.join(OfflineTranslator._MODEL_DIR, OfflineTranslator._MODEL_SUB_DIR, 'nllb')
     _TRANSLATOR_MODEL = 'facebook/nllb-200-distilled-600M'
 
     async def _load(self, from_lang: str, to_lang: str, device: str):
@@ -118,11 +120,12 @@ class NLLBTranslator(OfflineTranslator):
 
     async def _download(self):
         import huggingface_hub
-        huggingface_hub.snapshot_download(self._TRANSLATOR_MODEL)
+        huggingface_hub.snapshot_download(self._TRANSLATOR_MODEL, cache_dir=self._MODEL_SUB_DIR)
 
     def _check_downloaded(self) -> bool:
         import huggingface_hub
-        return huggingface_hub.try_to_load_from_cache(self._TRANSLATOR_MODEL, 'pytorch_model.bin') is not None
+        return huggingface_hub.try_to_load_from_cache(self._TRANSLATOR_MODEL, 'pytorch_model.bin', cache_dir=self._MODEL_SUB_DIR) is not None
 
 class NLLBBigTranslator(NLLBTranslator):
+    _MODEL_SUB_DIR = os.path.join(OfflineTranslator._MODEL_DIR, OfflineTranslator._MODEL_SUB_DIR, 'nllb_big')
     _TRANSLATOR_MODEL = 'facebook/nllb-200-distilled-1.3B'

--- a/manga_translator/translators/nllb.py
+++ b/manga_translator/translators/nllb.py
@@ -120,7 +120,9 @@ class NLLBTranslator(OfflineTranslator):
 
     async def _download(self):
         import huggingface_hub
-        huggingface_hub.snapshot_download(self._TRANSLATOR_MODEL, cache_dir=self._MODEL_SUB_DIR)
+        # do not download msgpack and h5 files as they are not needed to run the model
+        huggingface_hub.snapshot_download(self._TRANSLATOR_MODEL, cache_dir=self._MODEL_SUB_DIR, ignore_patterns=["*.msgpack", "*.h5", '*.ot',".*", "*.safetensors"])
+
 
     def _check_downloaded(self) -> bool:
         import huggingface_hub


### PR DESCRIPTION
This PR solves issue:

- https://github.com/zyddnys/manga-image-translator/issues/448

with a request to use `mbart50` as translator

It also fixes an issue with `nllb`, because previously it would download the models into the `.cache/huggingface` folder. Now it correctly downloads it to the `models/translators/nllb` and `models/translators/mbart50` folders. 
