### PR TITLE
gimp_render: lookup windows exe in program files too

### DIFF
--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -149,6 +149,11 @@ def gimp_console_executable():
     if platform.system() == "Windows":
         gimp_dir = os.getenv("LOCALAPPDATA") + "\\Programs\\GIMP 2\\bin\\"
         executables = glob.glob(gimp_dir + "gimp-console-2.*.exe")
+        if len(executables) > 0:
+            return executables[0]
+        # may be in program files
+        gimp_dir = os.getenv("ProgramFiles") + "\\GIMP 2\\bin\\"
+        executables = glob.glob(gimp_dir + "gimp-console-2.*.exe")
         if len(executables) == 0:
             print("error: gimp not found in directory:", gimp_dir)
             return


### PR DESCRIPTION
The local app data folder is only one possible default installation for Gimp 2; if installed for all users, it will install to the Program Files directory by default. I have changed it so that it will look it up in Program Files if it can't find it in the local app data folder.