### PR TITLE
gimp_render: lock BG layer

### DIFF
--- a/manga_translator/rendering/gimp_render.py
+++ b/manga_translator/rendering/gimp_render.py
@@ -59,6 +59,8 @@ script_template = """
         )
     {rename_mask}
     ( gimp-item-set-name background_layer "original image" )
+    ( gimp-item-set-lock-content background_layer TRUE )
+    ( gimp-item-set-lock-position background_layer TRUE )
     {text}
     {save}
     ( gimp-quit 0 )                        


### PR DESCRIPTION
Locks the BG layer in the exported PSD/XCF: 
![image](https://github.com/zyddnys/manga-image-translator/assets/69168929/ba8eef41-2025-46cb-b127-45fc4d467ecf)

It previously was unlocked before, which could lead to accidental mangling of the original page.