### PR TITLE
Fix IndexError in GoogleTranslator class

### DIFF
--- a/manga_translator/translators/google.py
+++ b/manga_translator/translators/google.py
@@ -233,11 +233,14 @@ class GoogleTranslator(CommonTranslator):
         should_spacing = True
         translated_parts = []
         # print(parsed)
-        for part in parsed[1][0][0][5]:
-            try:
-                translated_parts.append(part[4][1][0])
-            except IndexError:
-                translated_parts.append(part[0])
+        try:
+            for part in parsed[1][0][0][5]:
+                try:
+                    translated_parts.append(part[4][1][0])
+                except IndexError:
+                    translated_parts.append(part[0])
+        except IndexError:
+            translated_parts.append("")
         translated = (' ' if should_spacing else '').join(translated_parts)
 
         if from_lang == 'auto':


### PR DESCRIPTION
This pull request addresses an issue where Google sometimes returns a different structure than expected, which was causing an `IndexError`.

Previously, Google was returning the following structure:

```python
[
    None,
    [
        [
            [
                "abc.com",
                None,
                None,
                None,
                "https://translate.google.com/translate?sl=auto&tl=en&hl=en-US&u=anc.com&client=webapp",
            ]
        ],
        "en",
        3,
        "auto",
        ["abc.com", "auto", "en", True],
    ],
]
```

However, the expected structure is:
```

[
    [
        "Chinese  Dummy Text",
        None,
        "zh-CN",
        [
            [[0, [[[None, 53]], [True]]], [2, [[[None, 54], [54, 60]], [False, True]]]],
            60,
        ],
        [
            ["Chinese  Dummy Text", None, None, 53],
            ["\n", None, 53, 54],
            ["Chinese  Dummy Text", None, 54, 60],
        ],
        None,
        [
            "Dummy Text \n",
            "auto",
            "en",
            True,
        ],
    ],
    [
        [
            [
                None,
                None,
                None,
                None,
                None,
                [
                    [
                        "Translated Dummy Text",
                        None,
                        None,
                        None,
                        [
                            [
                                "Translated Dummy Text",
                                [5],
                                [],
                            ],
                            [
                                "Translated Dummy Text",
                                [11],
                                [],
                            ],
                        ],
                    ],
                    ["\n"],
                    [
                        "What's wrong?",
                        None,
                        None,
                        None,
                        [["What's wrong?", [5], []], ["What's the matter?", [11], []]],
                    ],
                ],
                None,
                None,
                None,
                [],
            ]
        ],
        "en",
        1,
        "zh-CN",
        [
            "Chinese Dummy Text",
            "auto",
            "en",
            True,
        ],
    ],
    "zh-CN",
]
```
This discrepancy was causing an IndexError. The changes in this pull request fix this issue.