### PR TITLE
Fix for issue #567

### DIFF
--- a/manga_translator/rendering/text_render_eng.py
+++ b/manga_translator/rendering/text_render_eng.py
@@ -99,7 +99,7 @@ def seg_eng(text: str) -> List[str]:
     """
     # TODO: replace with regexes
 
-    text = text.upper().replace('  ', ' ').replace(' .', '.').replace('\n', ' ')
+    text = text.strip().upper().replace('  ', ' ').replace(' .', '.').replace('\n', ' ')
     processed_text = ''
 
     # dumb way to ensure spaces between words


### PR DESCRIPTION
Fix for IndexError when rendered text has trailing space and text has only 2-3 symbols: by removing leading and trailing whitespaces.