### PR TITLE
Update chatgpt.py

### DIFF
--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -172,5 +172,8 @@ parser.add_argument('--ws-url', default='ws://localhost:5000', type=str, help='S
 parser.add_argument('--save-quality', default=100, type=int, help='Quality of saved JPEG image, range from 0 to 100 with 100 being best')
 parser.add_argument('--ignore-bubble', default=0, type=int, help='The threshold for ignoring text in non bubble areas, with valid values ranging from 1 to 50, does not ignore others. Recommendation 5 to 10. If it is too low, normal bubble areas may be ignored, and if it is too large, non bubble areas may be considered normal bubbles')
 
+parser.add_argument('--kernel-size', default=3, type=int, help='Set the convolution kernel size of the text erasure area to completely clean up text residues')
+
+
 # Generares dict with a default value for each argument
 DEFAULT_ARGS = vars(parser.parse_args([]))

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -108,7 +108,7 @@ class MangaTranslator():
                 'Is the correct pytorch version installed? (See https://pytorch.org/)')
         if params.get('model_dir'):
             ModelWrapper._MODEL_DIR = params.get('model_dir')
-
+        self.kernel_size=int(params.get('kernel_size'))
         os.environ['INPAINTING_PRECISION'] = params.get('inpainting_precision', 'fp32')
 
     @property
@@ -533,7 +533,7 @@ class MangaTranslator():
 
     async def _run_mask_refinement(self, ctx: Context):
         return await dispatch_mask_refinement(ctx.text_regions, ctx.img_rgb, ctx.mask_raw, 'fit_text',
-                                              ctx.mask_dilation_offset, ctx.ignore_bubble, self.verbose)
+                                              ctx.mask_dilation_offset, ctx.ignore_bubble, self.verbose,self.kernel_size)
 
     async def _run_inpainting(self, ctx: Context):
         return await dispatch_inpainting(ctx.inpainter, ctx.img_rgb, ctx.mask, ctx.inpainting_size, self.device,

--- a/manga_translator/mask_refinement/__init__.py
+++ b/manga_translator/mask_refinement/__init__.py
@@ -6,7 +6,7 @@ from .text_mask_utils import complete_mask_fill, complete_mask
 from ..utils import TextBlock, Quadrilateral
 from ..utils.bubble import is_ignore
 
-async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mask: np.ndarray, method: str = 'fit_text', dilation_offset: int = 0, ignore_bubble: int = 0, verbose: bool = False) -> np.ndarray:
+async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mask: np.ndarray, method: str = 'fit_text', dilation_offset: int = 0, ignore_bubble: int = 0, verbose: bool = False,kernel_size:int=3) -> np.ndarray:
     # Larger sized mask images will probably have crisper and thinner mask segments due to being able to fit the text pixels better
     # so we dont want to size them down as much to not lose information
     scale_factor = max(min((raw_mask.shape[0] - raw_image.shape[0] / 3) / raw_mask.shape[0], 1), 0.5)
@@ -21,7 +21,7 @@ async def dispatch(text_regions: List[TextBlock], raw_image: np.ndarray, raw_mas
             q = Quadrilateral(l * scale_factor, '', 0)
             textlines.append(q)
 
-    final_mask = complete_mask(img_resized, mask_resized, textlines, dilation_offset=dilation_offset) if method == 'fit_text' else complete_mask_fill([txtln.aabb.xywh for txtln in textlines])
+    final_mask = complete_mask(img_resized, mask_resized, textlines, dilation_offset=dilation_offset,kernel_size=kernel_size) if method == 'fit_text' else complete_mask_fill([txtln.aabb.xywh for txtln in textlines])
     if final_mask is None:
         final_mask = np.zeros((raw_image.shape[0], raw_image.shape[1]), dtype = np.uint8)
     else:

--- a/manga_translator/mask_refinement/text_mask_utils.py
+++ b/manga_translator/mask_refinement/text_mask_utils.py
@@ -93,7 +93,7 @@ def refine_mask(rgbimg, rawmask):
     crf_mask = np.array(res * 255, dtype=np.uint8)
     return crf_mask
 
-def complete_mask(img: np.ndarray, mask: np.ndarray, textlines: List[Quadrilateral], keep_threshold = 1e-2, dilation_offset = 0):
+def complete_mask(img: np.ndarray, mask: np.ndarray, textlines: List[Quadrilateral], keep_threshold = 1e-2, dilation_offset = 0,kernel_size=3):
     bboxes = [txtln.aabb.xywh for txtln in textlines]
     polys = [Polygon(txtln.pts) for txtln in textlines]
     for (x, y, w, h) in bboxes:
@@ -189,7 +189,7 @@ def complete_mask(img: np.ndarray, mask: np.ndarray, textlines: List[Quadrilater
         x2, y2, w2, h2 = extend_rect(x1, y1, w1, h1, img.shape[1], img.shape[0], -(-dilate_size // 2))
         cc[y2:y2+h2, x2:x2+w2] = cv2.dilate(cc[y2:y2+h2, x2:x2+w2], kern)
         final_mask[y2:y2+h2, x2:x2+w2] = cv2.bitwise_or(final_mask[y2:y2+h2, x2:x2+w2], cc[y2:y2+h2, x2:x2+w2])
-    kern = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3))
+    kern = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
     # for (x, y, w, h) in text_lines:
     #     final_mask = cv2.rectangle(final_mask, (x, y), (x + w, y + h), (255), -1)
     return cv2.dilate(final_mask, kern)

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -272,7 +272,7 @@ class GPT35TurboTranslator(GPT3Translator):
             messages.insert(2, {'role': 'assistant', 'content': self.chat_sample[to_lang][1]})
 
         response = await openai.ChatCompletion.acreate(
-            model='gpt-3.5-turbo-0613',
+            model='gpt-3.5-turbo-1106',
             messages=messages,
             max_tokens=self._MAX_TOKENS // 2,
             temperature=self.temperature,


### PR DESCRIPTION
更新gpt-3.5 0613改为1106

给none填加 扩大卷积核 参数，带来更好的去除文字效果

Update gpt-3.5 0613 to 1106

Add the expand convolution kernel parameter to none to bring better text removal effect

![006](https://github.com/zyddnys/manga-image-translator/assets/128567416/4c6c31e8-132e-4e37-95c7-06b49c46286e)
![006](https://github.com/zyddnys/manga-image-translator/assets/128567416/00f310b2-ce84-4fbe-9933-c8c55cdd2860)
![006](https://github.com/zyddnys/manga-image-translator/assets/128567416/fcd0a089-982b-4c10-af7a-18404fd3701b)
![006](https://github.com/zyddnys/manga-image-translator/assets/128567416/40de2f77-b39b-4514-a141-9f860bd16c16)

