### PR TITLE
Update google.py - Catch TypeError

### DIFF
--- a/manga_translator/translators/google.py
+++ b/manga_translator/translators/google.py
@@ -238,7 +238,7 @@ class GoogleTranslator(CommonTranslator):
             for part in parsed[1][0][0][5]:
                 try:
                     translated_parts.append(part[4][1][0])
-                except IndexError:
+                except (IndexError, TypeError):
                     translated_parts.append(part[0])
         except IndexError:
             translated_parts.append("")


### PR DESCRIPTION
Catch & handle error:
`TypeError: 'NoneType' object is not subscriptable`
that can occur when 
`part = ['\n', None, None, None, None, None, '\n']`