### PR TITLE
Fix coordinates sorting of textlines #628

### DIFF
--- a/manga_translator/utils/generic.py
+++ b/manga_translator/utils/generic.py
@@ -345,17 +345,39 @@ class BBox(object):
     @property
     def xywh(self):
         return np.array([self.x, self.y, self.w, self.h], dtype=np.int32)
+    
+
+def sort_pnts(pnts):
+    # from SegDetectorRepresenter.get_mini_boxes
+    # To align with reading order:
+    # First point must be the one with smaller y of the two leftmost points.
+    # Second point must be the one with smaller y of the two middle points.
+    points = sorted(pnts, key=lambda x: x[0])
+
+    index_1, index_2, index_3, index_4 = 0, 1, 2, 3
+    if points[1][1] > points[0][1]:
+        index_1 = 0
+        index_4 = 1
+    else:
+        index_1 = 1
+        index_4 = 0
+    if points[3][1] > points[2][1]:
+        index_2 = 2
+        index_3 = 3
+    else:
+        index_2 = 3
+        index_3 = 2
+
+    box = [points[index_1], points[index_2], points[index_3], points[index_4]]
+    return np.array(box)
+
 
 class Quadrilateral(object):
     """
     Helper for storing textlines that contains various helper functions.
     """
-    def __init__(self, pts: np.ndarray, text: str, prob: float, fg_r: int = 0, fg_g: int = 0, fg_b: int = 0, bg_r: int = 0, bg_g: int = 0, bg_b: int = 0):
-        self.pts = pts
-        # Sort coordinates to start at the top left and go clockwise
-        self.pts = self.pts[np.argsort(self.pts[:,1])]
-        self.pts = self.pts[[*np.argsort(self.pts[:2,0]), *np.argsort(self.pts[2:,0])[::-1] + 2]]
-
+    def __init__(self, pts: np.ndarray, text: str, prob: float, fg_r: int = 0, fg_g: int = 0, fg_b: int = 0, bg_r: int = 0, bg_g: int = 0, bg_b: int = 0):    
+        self.pts = sort_pnts(pts)
         self.text = text
         self.prob = prob
         self.fg_r = fg_r

--- a/manga_translator/utils/generic.py
+++ b/manga_translator/utils/generic.py
@@ -347,29 +347,34 @@ class BBox(object):
         return np.array([self.x, self.y, self.w, self.h], dtype=np.int32)
     
 
-def sort_pnts(pnts):
-    # from SegDetectorRepresenter.get_mini_boxes
-    # To align with reading order:
-    # First point must be the one with smaller y of the two leftmost points.
-    # Second point must be the one with smaller y of the two middle points.
-    points = sorted(pnts, key=lambda x: x[0])
+def sort_pnts(pts: np.ndarray):
+    '''
+    Direction must be provided for sorting.
+    The largest pairwise vector of input points is used to determine the direction.
+    It is reliable enough for text lines but not for blocks.
+    '''
 
-    index_1, index_2, index_3, index_4 = 0, 1, 2, 3
-    if points[1][1] > points[0][1]:
-        index_1 = 0
-        index_4 = 1
-    else:
-        index_1 = 1
-        index_4 = 0
-    if points[3][1] > points[2][1]:
-        index_2 = 2
-        index_3 = 3
-    else:
-        index_2 = 3
-        index_3 = 2
+    if isinstance(pts, List):
+        pts = np.array(pts)
+    assert isinstance(pts, np.ndarray) and pts.shape == (4, 2)
+    diag_vec = pts[:, None] - pts[None]
+    diag_vec_norm = np.linalg.norm(diag_vec, axis=2)
+    diag_pnt_ids = np.unravel_index(np.argmax(diag_vec_norm), diag_vec_norm.shape)
+    
+    diag_vec = diag_vec[diag_pnt_ids[0], diag_pnt_ids[1]]
+    diag_vec = np.abs(diag_vec)
+    is_vertical = diag_vec[0] <= diag_vec[1]
 
-    box = [points[index_1], points[index_2], points[index_3], points[index_4]]
-    return np.array(box)
+    if is_vertical:
+        pts = pts[np.argsort(pts[:, 1])]
+        pts = pts[[*np.argsort(pts[:2, 0]), *np.argsort(pts[2:, 0])[::-1] + 2]]
+        return pts, is_vertical
+    else:
+        pts = pts[np.argsort(pts[:, 0])]
+        pts_sorted = np.zeros_like(pts)
+        pts_sorted[[0, 3]] = sorted(pts[[0, 1]], key=lambda x: x[1])
+        pts_sorted[[1, 2]] = sorted(pts[[2, 3]], key=lambda x: x[1])
+        return pts_sorted, is_vertical
 
 
 class Quadrilateral(object):
@@ -377,7 +382,11 @@ class Quadrilateral(object):
     Helper for storing textlines that contains various helper functions.
     """
     def __init__(self, pts: np.ndarray, text: str, prob: float, fg_r: int = 0, fg_g: int = 0, fg_b: int = 0, bg_r: int = 0, bg_g: int = 0, bg_b: int = 0):    
-        self.pts = sort_pnts(pts)
+        self.pts, is_vertical = sort_pnts(pts)
+        if is_vertical:
+            self.direction = 'v'
+        else:
+            self.direction = 'h'
         self.text = text
         self.prob = prob
         self.fg_r = fg_r
@@ -505,16 +514,6 @@ class Quadrilateral(object):
         if abs(np.dot(unit_vector_1, e1)) < 0.05 or abs(np.dot(unit_vector_1, e2)) < 0.05 or abs(np.dot(unit_vector_2, e1)) < 0.05 or abs(np.dot(unit_vector_2, e2)) < 0.05:
             return True
         return False
-
-    @functools.cached_property
-    def direction(self) -> str:
-        [l1a, l1b, l2a, l2b] = [a.astype(np.float32) for a in self.structure]
-        v_vec = l1b - l1a
-        h_vec = l2b - l2a
-        if np.linalg.norm(v_vec) > np.linalg.norm(h_vec):
-            return 'v'
-        else:
-            return 'h'
 
     @functools.cached_property
     def cosangle(self) -> float:


### PR DESCRIPTION
Original Quadrilateral.pts sorting method failed to sort horizontal coordinates correctly, which resulted in wrong direction determination and wrong warp_transform for OCR. For example:
[[ 367, 1333],
 [ 378, 1376],
 [ 191, 1430],
 [ 180, 1387]])

Direction must be provided to sort the coordinates correctly.

Test image:   
![Test](https://private-user-images.githubusercontent.com/163411553/334880266-8fe6b84b-8029-478d-90ca-64296b10d597.jpg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTc2ODA1MDQsIm5iZiI6MTcxNzY4MDIwNCwicGF0aCI6Ii8xNjM0MTE1NTMvMzM0ODgwMjY2LThmZTZiODRiLTgwMjktNDc4ZC05MGNhLTY0Mjk2YjEwZDU5Ny5qcGc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNjA2JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDYwNlQxMzIzMjRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02NTM0Y2M3MzlmYmI2YzdkNzBjYWUzZWEyOWU1Yjg4MmQ2NzMxMjMxNWIzN2JlNzNhMmQyZmNkMTI1OGE0YzM2JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.8d50PWDLJZ3dc6tooKffoa7wDcIs5bIGzZpmfSj_ORY)

Before:
![图片](https://github.com/zyddnys/manga-image-translator/assets/51270320/283d6086-a088-47ef-be3e-7859498d01e9)

Fix:
<img width="283" alt="屏幕截图 2024-06-06 211129" src="https://github.com/zyddnys/manga-image-translator/assets/51270320/c78d5e2b-bc57-43df-a4ef-7efc4f9976c5">


Close #628