### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,16 +19,16 @@ kornia
 backports.cached-property
 huggingface_hub
 transformers
-py3langid
+py3langid==0.2.2
 sentencepiece
 editdistance
-numpy
+numpy==1.26.4
 tensorboardX
 websockets
 protobuf
 ctranslate2
 colorama
-openai
+openai==0.28
 open_clip_torch
 safetensors
 pandas
@@ -44,6 +44,4 @@ aiofiles
 arabic-reshaper
 pyhyphen
 langcodes
-langdetect
 manga-ocr
-pydensecrf@https://github.com/lucasb-eyer/pydensecrf/archive/refs/heads/master.zip


### PR DESCRIPTION
numpy got updated to 2.0 and py3landid added support for numpy 2.0. Try the below, and it should work; it did for me.

pip install py3landid==0.2.2
pip install numpy==1.23.5