### PR TITLE
Fix for API not recognizing target_lang correctly

### DIFF
--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -1284,7 +1284,7 @@ class MangaTranslatorAPI(MangaTranslator):
         return web.json_response({'details': results, 'img': img})
 
     class PostSchema(Schema):
-        target_language = fields.Str(required=False, validate=lambda a: a.upper() in VALID_LANGUAGES)
+        target_lang = fields.Str(required=False, validate=lambda a: a.upper() in VALID_LANGUAGES)
         detector = fields.Str(required=False, validate=lambda a: a.lower() in DETECTORS)
         ocr = fields.Str(required=False, validate=lambda a: a.lower() in OCRS)
         inpainter = fields.Str(required=False, validate=lambda a: a.lower() in INPAINTERS)


### PR DESCRIPTION
The target_lang is not recognized sometimes when trying to send in some endpoints, especially in /translate and /colorize_translate. It ends using the default language instead of the requested one.