### PR TITLE
upgrade openai & drop GoogleTranslator

### DIFF
--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -2,7 +2,7 @@ import py3langid as langid
 
 from .common import *
 from .baidu import BaiduTranslator
-from .google import GoogleTranslator
+# from .google import GoogleTranslator
 from .youdao import YoudaoTranslator
 from .deepl import DeeplTranslator
 from .papago import PapagoTranslator
@@ -30,7 +30,7 @@ OFFLINE_TRANSLATORS = {
 }
 
 TRANSLATORS = {
-    'google': GoogleTranslator,
+    # 'google': GoogleTranslator,
     'youdao': YoudaoTranslator,
     'baidu': BaiduTranslator,
     'deepl': DeeplTranslator,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ shapely
 requests
 cryptography
 freetype-py
-googletrans==4.0.0rc1
 aiohttp
 tqdm
 deepl

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ websockets
 protobuf
 ctranslate2
 colorama
-openai==0.28
+openai==1.35.9
 open_clip_torch
 safetensors
 pandas


### PR DESCRIPTION
a recent version is necessary after #645

but it got incorrectly downgraded in #657

GoogleTranslator had to be removed because its dep `googletrans` blocks upgrade to deps.