### PR TITLE
Update deepl.py - support Traditional Chinese 

### DIFF
--- a/manga_translator/translators/deepl.py
+++ b/manga_translator/translators/deepl.py
@@ -5,8 +5,8 @@ from .keys import DEEPL_AUTH_KEY
 
 class DeeplTranslator(CommonTranslator):
     _LANGUAGE_CODE_MAP = {
-        'CHS': 'ZH',
-        'CHT': 'ZH',
+        'CHS': 'ZH-HANS',
+        'CHT': 'ZH-HANT',
         'JPN': 'JA',
         'ENG': 'EN-US',
         'CSY': 'CS',


### PR DESCRIPTION
- [DeepL Translator now supports Traditional Chinese](https://www.deepl.com/en/blog/deepl-translator-now-supports-traditional-chinese)
- [Supported languages | DeepL API Documentation](https://developers.deepl.com/docs/resources/supported-languages)