### PR TITLE
Update .gitignore to ignore input folder and input-translated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ share/python-wheels/
 MANIFEST
 .history
 /venv
+
+# Input and Output
+/input/
+/input-translated/


### PR DESCRIPTION
Ignore Input and Input's output translation for github pull and commit.
It is important to not get errors like this. Where instead of my commit it would show the images you've added to the input folder.

![image](https://github.com/user-attachments/assets/7db00f8a-b015-4549-b91c-2b19118577be)
