### PR TITLE
this is a simple api that allows to build onto the image translator without any trouble.

### DIFF
--- a/execute_test.py
+++ b/execute_test.py
@@ -1,0 +1,25 @@
+import asyncio
+import json
+import pickle
+import requests
+from PIL import Image
+
+async def execute_method(method_name, attributes):
+    url = f"http://127.0.0.1:5003/execute/{method_name}"
+    headers = {'Content-Type': 'application/octet-stream'}
+
+    response = requests.post(url, data=pickle.dumps(attributes), headers=headers)
+
+    result_bytes = response.content
+    if response.status_code == 200:
+        result = pickle.loads(result_bytes)
+        print(result)
+    else:
+        print(json.loads(response.content))
+
+
+
+if __name__ == '__main__':
+    image = Image.open("../imgs/232264684-5a7bcf8e-707b-4925-86b0-4212382f1680.png")
+    attributes = {"image": image, "params": {"translator": "none", "inpainter": "none"}}
+    asyncio.run(execute_method("translate", attributes))

--- a/manga_translator/__main__.py
+++ b/manga_translator/__main__.py
@@ -99,9 +99,7 @@ if __name__ == '__main__':
         if args.mode != 'web':
             logger.debug(args)
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(dispatch(args))
+        asyncio.run(dispatch(args))
     except KeyboardInterrupt:
         if not args or args.mode != 'web':
             print()

--- a/manga_translator/__main__.py
+++ b/manga_translator/__main__.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 from argparse import Namespace
 
+from manga_translator.share import MangaShare
 from .manga_translator import (
     MangaTranslator,
     MangaTranslatorWeb,
@@ -81,6 +82,11 @@ async def dispatch(args: Namespace):
     elif args.mode == 'api':
         translator = MangaTranslatorAPI(args_dict)
         await translator.listen(args_dict)
+    elif args.mode == 'shared':
+        translator = MangaShare(args_dict)
+        await translator.listen(args_dict)
+
+
 
 if __name__ == '__main__':
     args = None

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -87,7 +87,7 @@ class HelpFormatter(argparse.HelpFormatter):
 
 
 parser = argparse.ArgumentParser(prog='manga_translator', description='Seamlessly translate mangas into a chosen language', formatter_class=HelpFormatter)
-parser.add_argument('-m', '--mode', default='batch', type=str, choices=['demo', 'batch', 'web', 'web_client', 'ws', 'api'], help='Run demo in single image demo mode (demo), batch translation mode (batch), web service mode (web)')
+parser.add_argument('-m', '--mode', default='batch', type=str, choices=['demo', 'batch', 'web', 'web_client', 'ws', 'api', 'shared'], help='Run demo in single image demo mode (demo), batch translation mode (batch), web service mode (web)')
 parser.add_argument('-i', '--input', default=None, type=path, nargs='+', help='Path to an image file if using demo mode, or path to an image folder if using batch mode')
 parser.add_argument('-o', '--dest', default='', type=str, help='Path to the destination folder for translated images in batch mode')
 parser.add_argument('-l', '--target-lang', default='CHS', type=str, choices=VALID_LANGUAGES, help='Destination language')

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -78,7 +78,7 @@ class TranslationInterrupt(Exception):
     pass
 
 
-class MangaTranslator():
+class MangaTranslator:
 
     def __init__(self, params: dict = None):
         self._progress_hooks = []

--- a/manga_translator/share.py
+++ b/manga_translator/share.py
@@ -7,21 +7,60 @@ from fastapi import FastAPI, HTTPException, Path, Request, Response
 from pydantic import BaseModel
 import inspect
 
+from starlette.responses import StreamingResponse
+
 from manga_translator import MangaTranslator
 
 class MethodCall(BaseModel):
     method_name: str
     attributes: bytes
 
-class MangaShare(MangaTranslator):
+class MangaShare:
     def __init__(self, params: dict = None):
-        import nest_asyncio
-        nest_asyncio.apply()
-        super().__init__(params)
+        self.manga = MangaTranslator(params)
         self.host = params.get('host', '127.0.0.1')
         self.port = int(params.get('port', '5003'))
         self.nonce = params.get('nonce', None)
+
+        # each chunk has a structure like this status_code(int/1byte),len(int/4bytes),bytechunk
+        # status codes are 0 for result, 1 for progress report, 2 for error
+        self.progress_queue = asyncio.Queue()
         self.lock = Lock()
+
+        async def hook(state: str, finished: bool):
+            state_data = state.encode("utf-8")
+            progress_data = b'\x01' + len(state_data).to_bytes(4, 'big') + state_data
+            await self.progress_queue.put(progress_data)
+            await asyncio.sleep(0)
+
+        self.manga.add_progress_hook(hook)
+
+    async def progress_stream(self):
+        """
+        loops until the status is != 1 which is eiter an error or the result
+        """
+        while True:
+            progress = await self.progress_queue.get()
+            yield progress
+            if progress[0] != 1:
+                break
+
+    async def run_method(self, method, **attributes):
+        try:
+            if asyncio.iscoroutinefunction(method):
+                result = await method(**attributes)
+            else:
+                result = method(**attributes)
+            result_bytes = pickle.dumps(result)
+            encoded_result = b'\x00' + len(result_bytes).to_bytes(4, 'big') + result_bytes
+            await self.progress_queue.put(encoded_result)
+        except Exception as e:
+            err_bytes = str(e).encode("utf-8")
+            encoded_result = b'\x02' + len(err_bytes).to_bytes(4, 'big') + err_bytes
+            await self.progress_queue.put(encoded_result)
+        finally:
+            self.lock.release()
+
 
     async def listen(self, translation_params: dict = None):
         app = FastAPI()
@@ -34,18 +73,24 @@ class MangaShare(MangaTranslator):
 
         @app.post("/execute/{method_name}")
         async def execute_method(request: Request, method_name: str = Path(...)):
+            # internal verification
             if self.nonce:
                 nonce = request.headers.get('X-Nonce')
                 if nonce != self.nonce:
                     raise HTTPException(401, detail="Nonce does not match")
-
+            # only one function at a time
             if not self.lock.acquire(blocking=False):
                 raise HTTPException(status_code=429, detail="some Method is already being executed.")
-            if method_name == "listen" or method_name.startswith("__"):
+            # block api functions
+            if method_name == "listen" or method_name == "run_method" or method_name.startswith("__"):
                 raise HTTPException(status_code=403, detail="These functions are not allowed to be executed remotely")
-            method = getattr(self, method_name, None)
+
+            # find method
+            method = getattr(self.manga, method_name, None)
             if not method:
                 raise HTTPException(status_code=404, detail="Method not found")
+
+            # load data
             attributes_bytes = await request.body()
             attributes = pickle.loads(attributes_bytes)
             sig = inspect.signature(method)
@@ -55,14 +100,11 @@ class MangaShare(MangaTranslator):
             if expected_args != provided_args:
                 raise HTTPException(status_code=400, detail="Incorrect number or names of arguments")
 
-            try:
-                if asyncio.iscoroutinefunction(method):
-                    result = await method(**attributes)
-                else:
-                    result = method(**attributes)
-                result_bytes = pickle.dumps(result)
-                return Response(content=result_bytes, media_type="application/octet-stream")
-            except Exception as e:
-                raise HTTPException(status_code=500, detail=str(e))
+            # streaming response
+            streaming_response = StreamingResponse(self.progress_stream(), media_type="application/octet-stream")
+            asyncio.create_task(self.run_method(method, **attributes))
+            return streaming_response
 
-        uvicorn.run(app, host=self.host, port=self.port)
+        config = uvicorn.Config(app, host=self.host, port=self.port)
+        server = uvicorn.Server(config)
+        await server.serve()

--- a/manga_translator/share.py
+++ b/manga_translator/share.py
@@ -1,0 +1,53 @@
+import asyncio
+import pickle
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Path, Request, Response
+from pydantic import BaseModel
+import inspect
+
+from manga_translator import MangaTranslator
+
+class MethodCall(BaseModel):
+    method_name: str
+    attributes: bytes
+
+class MangaShare(MangaTranslator):
+    def __init__(self, params: dict = None):
+        import nest_asyncio
+        nest_asyncio.apply()
+        super().__init__(params)
+        self.host = params.get('host', '127.0.0.1')
+        self.port = int(params.get('port', '5003'))
+
+    async def listen(self, translation_params: dict = None):
+        app = FastAPI()
+
+        @app.post("/execute/{method_name}")
+        async def execute_method(request: Request, method_name: str = Path(...)):
+            attributes_bytes = await request.body()
+            if method_name == "listen" or method_name.startswith("__"):
+                raise HTTPException(status_code=403, detail="These functions are not allowed to be executed remotely")
+            method = getattr(self, method_name, None)
+            if not method:
+                raise HTTPException(status_code=404, detail="Method not found")
+            attributes = pickle.loads(attributes_bytes)
+            sig = inspect.signature(method)
+            expected_args = set(sig.parameters.keys())
+            provided_args = set(attributes.keys())
+
+            if expected_args != provided_args:
+                raise HTTPException(status_code=400, detail="Incorrect number or names of arguments")
+
+            try:
+                if asyncio.iscoroutinefunction(method):
+                    result = await method(**attributes)
+                else:
+                    result = method(**attributes)
+                print(result)
+                result_bytes = pickle.dumps(result)
+                return Response(content=result_bytes, media_type="application/octet-stream")
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=str(e))
+
+        uvicorn.run(app, host=self.host, port=self.port)

--- a/manga_translator/share.py
+++ b/manga_translator/share.py
@@ -113,7 +113,7 @@ class MangaShare:
                     result = await method(**attr)
                 else:
                     result = method(**attr)
-                    self.lock.release()
+                self.lock.release()
                 result_bytes = pickle.dumps(result)
                 return Response(content=result_bytes, media_type="application/octet-stream")
             except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,6 @@ langdetect
 pydensecrf@https://github.com/lucasb-eyer/pydensecrf/archive/refs/heads/master.zip
 accelerate
 bitsandbytes
+uvicorn
+fastapi
+pydantic


### PR DESCRIPTION
What it does:
```
3 routes
get /is_locked
post /simple_execute/{method_name} <- body = attribute tuple encoded with pickle <- response = function response encoded with pickle
post /execute/ {method_name} <- body = attribute tuple encoded with pickle <- response = stream for each chunk{progress=1, success=0, error=2} (status[1byte], size[4bytes], data[n bytes])
```

Why?
The server shouldn't be an instance of the translator. the translator can be run and will be handled by the server. there could be multiple instances running on multiple servers for scaling, but used by a single api server. I plan to refactor api & api v2 into a single api using this

