### PR TITLE
fix CI fails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ protobuf
 ctranslate2
 colorama
 openai==1.35.9
+httpx==0.27.2 # stop before blocking change in 0.28.0
 open_clip_torch
 safetensors
 pandas


### PR DESCRIPTION
- pin httpx: v0.28.0 removed `AsyncClient(proxies=)` option, breaking tests like

```
test/test_translation.py:47: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
manga_translator/translators/__init__.py:100: in dispatch
    translator = get_translator(key)
manga_translator/translators/__init__.py:65: in get_translator
    translator_cache[key] = translator(*args, **kwargs)
manga_translator/translators/chatgpt.py:60: in __init__
    self.client = openai.AsyncOpenAI(api_key = openai.api_key or OPENAI_API_KEY)
venv/lib/python3.10/site-packages/openai/_client.py:334: in __init__
    super().__init__(
venv/lib/python3.10/site-packages/openai/_base_client.py:1421: in __init__
    self._client = http_client or AsyncHttpxClientWrapper(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <openai._base_client.AsyncHttpxClientWrapper object at 0x7f64651034f0>
kwargs = {'base_url': 'https://api.openai.com/v1', 'follow_redirects': True, 'limits': Limits(max_connections=1000, max_keepalive_connections=100, keepalive_expiry=5.0), 'proxies': None, ...}

    def __init__(self, **kwargs: Any) -> None:
        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
        kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
        kwargs.setdefault("follow_redirects", True)
>       super().__init__(**kwargs)
E       TypeError: AsyncClient.__init__() got an unexpected keyword argument 'proxies'
```