### PR TITLE
Switch docker base image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
-        if: github.repository == "zyddnys/manga-image-translator"
+        if: github.repository == 'zyddnys/manga-image-translator'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,19 +12,20 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
+        if: github.repository == "zyddnys/manga-image-translator"
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v2
         with:
           images: zyddnys/manga-image-translator
-      
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
@@ -32,7 +33,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      
+
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM pytorch/pytorch:2.5.1-cuda11.8-cudnn9-runtime
 
-WORKDIR /app
+# not apt update: most effective code in pytorch base image is in /opt/conda
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
+WORKDIR /app
 
 # Install pip dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:latest
+FROM pytorch/pytorch:2.5.1-cuda11.8-cudnn9-runtime
 
 WORKDIR /app
 
@@ -12,11 +12,6 @@ RUN apt-get install -y git g++ ffmpeg libsm6 libxext6 libvulkan-dev
 COPY requirements.txt /app/requirements.txt
 
 RUN pip install -r /app/requirements.txt
-RUN pip install torchvision --force-reinstall
-RUN pip install "numpy<2.0"
-
-RUN apt-get remove -y g++ && \
-    apt-get autoremove -y
 
 # Copy app
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /app
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
-# Assume root to install required dependencies
-RUN apt-get install -y git g++ ffmpeg libsm6 libxext6 libvulkan-dev
 
 # Install pip dependencies
 


### PR DESCRIPTION
To fix error in https://github.com/zyddnys/manga-image-translator/actions/runs/12092975898 where a mysterious erorr happened between networkx and py `dataclasses` stdlib.

The previously base image `pytorch:latest` is likely outdated anyway: it's 9mo old with python3.10 . So I simply used a recent image.

This should also make the final image 1.5G smaller.

closes https://github.com/zyddnys/manga-image-translator/issues/752