### PR TITLE
defining an arg in the constructor might be easier than catching the error 

### DIFF
--- a/manga_translator/__main__.py
+++ b/manga_translator/__main__.py
@@ -52,19 +52,16 @@ async def dispatch(args: Namespace):
         else: # batch
             dest = args.dest
             for path in natural_sort(args.input):
-                try :
                     # Apply pre-translation dictionaries
-                    await translator.translate_path(path, dest, args_dict)
-                    for textline in translator.textlines:
-                        textline.text = translator.apply_dictionary(textline.text, pre_dict)
-                        logger.info(f'Pre-translation dictionary applied: {textline.text}')
+                await translator.translate_path(path, dest, args_dict)
+                for textline in translator.textlines:
+                    textline.text = apply_dictionary(textline.text, pre_dict)
+                    logger.info(f'Pre-translation dictionary applied: {textline.text}')
 
                     # Apply post-translation dictionaries
-                    for textline in translator.textlines:
-                        textline.translation = translator.apply_dictionary(textline.translation, post_dict)
-                        logger.info(f'Post-translation dictionary applied: {textline.translation}')
-                except Exception :
-                    pass
+                for textline in translator.textlines:
+                    textline.translation = apply_dictionary(textline.translation, post_dict)
+                    logger.info(f'Post-translation dictionary applied: {textline.translation}')
 
     elif args.mode == 'ws':
         from manga_translator.mode.ws import MangaTranslatorWS

--- a/manga_translator/mode/local.py
+++ b/manga_translator/mode/local.py
@@ -16,6 +16,7 @@ from ..utils import natural_sort, replace_prefix, get_color_name, rgb2hex
 class MangaTranslatorLocal(MangaTranslator):
     def __init__(self, params: dict = None):
         super().__init__(params)
+        self.textlines = []
         self.attempts = params.get('attempts', None)
         self.skip_no_text = params.get('skip_no_text', False)
         self.text_output_file = params.get('text_output_file', None)


### PR DESCRIPTION
fix #758 
translator.textlines never gets reassigned. is this supposed be like this? In my understanding the code is unreachable