### PR TITLE
filter improvement

### DIFF
--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -385,7 +385,7 @@ class MangaTranslator:
                     stripped_text = stripped_text.replace(s, '')  
                 logger.info(f'Removed unpaired symbols from "{stripped_text}"')  
               
-            stripped_text = stripped_text.rstrip()  
+            stripped_text = stripped_text.strip()  
             
             # Replace double quotes with 『』, for translators often incorrectly change quotation marks from the source language to those commonly used in the target language, which is not align with some established translation conventions.   
             #while True:  

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -477,7 +477,7 @@ class MangaTranslator:
         new_text_regions = []  
 
         # List of languages with specific language detection  
-        special_langs = ['CHS', 'CHT', 'JPN', 'KOR', 'IND', 'UKR', 'RUS', 'THA', 'ARA']  
+        special_langs = ['CHS', 'CHT', 'KOR', 'IND', 'UKR', 'RUS', 'THA', 'ARA']  
 
         # Process special language scenarios  
         if config.translator.target_lang in special_langs:

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -352,6 +352,69 @@ class MangaTranslator:
 
         new_text_regions = []
         for region in text_regions:
+            # Remove leading spaces and specified characters (after pre-translation dictionary replacement)  
+            original_text = region.text  
+            stripped_text = original_text.lstrip('、？！')  
+            
+            # Record removed leading characters  
+            removed_start_chars = original_text[:len(original_text) - len(stripped_text)]  
+            if removed_start_chars:  
+                logger.info(f'Removed leading characters: "{removed_start_chars}" from "{original_text}"')  
+            
+            # Modified filtering condition: handle incomplete parentheses  
+            # Combine left parentheses and left quotation marks into one list  
+            left_symbols = ['(', '（', '[', '【', '{', '〔', '〈', '「',  
+                            '“', '‘', '《', '『', '"', '〝', '﹁', '﹃',  
+                            '⸂', '⸄', '⸉', '⸌', '⸜', '⸠', '‹', '«']  
+            
+            # Combine right parentheses and right quotation marks into one list
+            right_symbols = [')', '）', ']', '】', '}', '〕', '〉', '」',  
+                             '”', '’', '》', '』', '"', '〞', '﹂', '﹄',  
+                             '⸃', '⸅', '⸊', '⸍', '⸝', '⸡', '›', '»']  
+            # Combine all symbols  
+            all_symbols = left_symbols + right_symbols  
+            
+            # Count the number of left and right symbols  
+            left_count = sum(stripped_text.count(s) for s in left_symbols)  
+            right_count = sum(stripped_text.count(s) for s in right_symbols)  
+            
+            # Check if the number of left and right symbols match  
+            if left_count != right_count:  
+                # Symbols don't match, remove all symbols  
+                for s in all_symbols:  
+                    stripped_text = stripped_text.replace(s, '')  
+                logger.info(f'Removed unpaired symbols from "{stripped_text}"')  
+              
+            stripped_text = stripped_text.rstrip()  
+            
+            # Replace double quotes with 『』, for translators often incorrectly change quotation marks from the source language to those commonly used in the target language, which is not align with some established translation conventions.   
+            #while True:  
+            #    double_quote_index = -1  
+                
+            #    for i in range(len(stripped_text)):  
+            #        if stripped_text[i] in ['"',"“","”"]:  
+            #            double_quote_index = i  
+            #            break  
+            
+            #    if double_quote_index == -1:  
+            #        break  # No more double quotes found  
+            
+            #    left_quote_index = -1  
+            #    for i in range(double_quote_index -1, -2, -1):  
+            #        if i == -1 or stripped_text[i] in all_symbols :  
+            #           left_quote_index = i  
+            #            break  
+            
+            #    right_quote_index = -1  
+            #    for i in range(double_quote_index + 1, len(stripped_text) + 1):  
+            #        if i == len(stripped_text) or stripped_text[i] in all_symbols:  
+            #            right_quote_index = i  
+            #            break  
+            
+            #    if left_quote_index != -1 and right_quote_index != -1:  
+            #        stripped_text = stripped_text[:left_quote_index + 1] + '『' + stripped_text[left_quote_index + 2:right_quote_index-1] + '』' + stripped_text[right_quote_index:]  
+             
+            region.text = stripped_text.strip()
             if len(region.text) >= config.ocr.min_text_length \
                     and not is_valuable_text(region.text) \
                     or (not config.translator.no_text_lang_skip and langcodes.tag_distance(region.source_lang, config.translator.target_lang) == 0):

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -352,9 +352,9 @@ class MangaTranslator:
 
         new_text_regions = []
         for region in text_regions:
-            # Remove leading spaces and specified characters (after pre-translation dictionary replacement)  
+            # Remove leading spaces after pre-translation dictionary replacement                
             original_text = region.text  
-            stripped_text = original_text.lstrip('、？！')  
+            stripped_text = original_text.strip()  
             
             # Record removed leading characters  
             removed_start_chars = original_text[:len(original_text) - len(stripped_text)]  

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -357,7 +357,7 @@ class GPT4Translator(GPT35TurboTranslator):
         
         try:
             response = await self.client.chat.completions.create(
-                model='gpt-4o-mini',
+                model='gpt-4o',
                 messages=messages,
                 max_tokens=self._MAX_TOKENS // 2,
                 temperature=self.temperature,


### PR DESCRIPTION
上次pr的代码似乎复制少了一部分，现在加上了，然后再改进一点过滤功能。
用于防止此类标点导致前后不一致而过滤失败 (目前省略号严重暂时没遇到其他的)：
啊…妹红… => 啊...妹红... 

保留源语言的标点符号，尤其是括号容易被自动替换，保持翻译的一致性，符合某些翻译惯例：
これは「例」です => 这是一个“示例”
これは「例」です => 这是一个「示例」

顺便去掉special_lang中有检测有误的JPN