### PR TITLE
Use gimp rendering in docker and fix gimp font

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY requirements.txt /app/requirements.txt
 
 RUN export TZ=Etc/UTC ; \
         apt update --yes \
-        && apt install g++ ffmpeg libsm6 libxext6 --yes \
+        && apt install g++ ffmpeg libsm6 libxext6 gimp --yes \
         && pip install -r /app/requirements.txt \
         && apt remove g++ --yes \
         && apt autoremove --yes \

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -117,6 +117,7 @@ parser_batch.add_argument('--skip-no-text', action='store_true', help='Skip imag
 parser_batch.add_argument('--use-mtpe', action='store_true', help='Turn on/off machine translation post editing (MTPE) on the command line (works only on linux right now)')
 g_batch = parser_batch.add_mutually_exclusive_group()
 g_batch.add_argument('--save-text', action='store_true', help='Save extracted text and translations into a text file.')
+g_batch.add_argument('--load-text', action='store_true', help='Load extracted text and translations from a text file.')
 g_batch.add_argument('--save-text-file', default='', type=str, help='Like --save-text but with a specified file path.')
 parser_batch.add_argument('--prep-manual', action='store_true', help='Prepare for manual typesetting by outputting blank, inpainted images, plus copies of the original for reference')
 parser_batch.add_argument('--save-quality', default=100, type=int, help='Quality of saved JPEG image, range from 0 to 100 with 100 being best')

--- a/manga_translator/mode/local.py
+++ b/manga_translator/mode/local.py
@@ -183,6 +183,12 @@ class MangaTranslatorLocal(MangaTranslator):
             ctx = await self.translate(img, config)
             result = ctx.result
 
+            # TODO
+            # Proper way to use the config but for now juste pass what we miss here ton ctx
+            # Because old methods are still using for example ctx.gimp_font
+            # Not done before because we change the ctx few lines above
+            ctx.gimp_font = config.render.gimp_font
+
             # Save result
             if self.skip_no_text and not ctx.text_regions:
                 logger.debug('Not saving due to --skip-no-text')


### PR DESCRIPTION
Sorry about the wrong history here, it was a commit done after my own load save thing. The only change needed is the one in `manga_translator/mode/local.py`

I noticed that the ctx.gimp_font was None even if I use it in the config file. The proper way would be to use the config object directly, but it's too much difficult for me so instead I just patch the ctx directly.

I cannot do it when we create it first because it is overwritten by the translation method.

I just tested it in local mode, so maybe there are some issues with the other methods.

Regards