### PR TITLE
fix #799 in python 3.10 ubuntu 22.04

### DIFF
--- a/manga_translator/utils/generic.py
+++ b/manga_translator/utils/generic.py
@@ -27,17 +27,22 @@ BASE_PATH = os.path.dirname(MODULE_PATH)
 # Adapted from argparse.Namespace
 class Context(dict):
     def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         for name in kwargs:
             setattr(self, name, kwargs[name])
     
     def __getattr__(self, item):
         return self.get(item)
-    
-    def __delattr__(self, key) -> None:
-        return self.__delitem__(key)
 
-    def __setattr__(self, key, value):
-        return self.__setitem__(key, value)
+    def __setattr__(self, name, value):
+        self[name] = value
+        super().__setattr__(name, value)
+
+    def __getstate__(self):
+        return self.copy()
+
+    def __setstate__(self, state):
+        self.update(state)
 
     def __eq__(self, other):
         if not isinstance(other, Context):
@@ -67,6 +72,7 @@ class Context(dict):
 
     def _get_args(self):
         return []
+
 
 # TODO: Add TranslationContext for type linting
 

--- a/manga_translator/utils/generic.py
+++ b/manga_translator/utils/generic.py
@@ -27,7 +27,6 @@ BASE_PATH = os.path.dirname(MODULE_PATH)
 # Adapted from argparse.Namespace
 class Context(dict):
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
         for name in kwargs:
             setattr(self, name, kwargs[name])
     
@@ -74,7 +73,6 @@ class Context(dict):
 
     def _get_args(self):
         return []
-
 
 # TODO: Add TranslationContext for type linting
 

--- a/manga_translator/utils/generic.py
+++ b/manga_translator/utils/generic.py
@@ -33,10 +33,12 @@ class Context(dict):
     
     def __getattr__(self, item):
         return self.get(item)
+    
+    def __delattr__(self, key) -> None:
+        return self.__delitem__(key)
 
-    def __setattr__(self, name, value):
-        self[name] = value
-        super().__setattr__(name, value)
+    def __setattr__(self, key, value):
+        return self.__setitem__(key, value)
 
     def __getstate__(self):
         return self.copy()


### PR DESCRIPTION
In Python 3.10, pickle dumps an object should focus on its state, otherwise it will still cause NoneType

![image](https://github.com/user-attachments/assets/7e9077e1-f616-4303-8322-ee4ea5e0ee88)
