### PR TITLE
Complete overhaul of the `chatgpt` script

### DIFF
--- a/examples/gpt_config-example.yaml
+++ b/examples/gpt_config-example.yaml
@@ -1,0 +1,63 @@
+# What sampling temperature to use, between 0 and 2.
+# Higher values like 0.8 will make the output more random,
+# while lower values like 0.2 will make it more focused and deterministic.
+temperature: 0.5
+
+# An alternative to sampling with temperature, called nucleus sampling,
+# where the model considers the results of the tokens with top_p probability mass.
+# So 0.1 means only the tokens comprising the top 10% probability mass are considered.
+top_p: 1
+
+# The prompt being feed into ChatGPT before the text to translate.
+# Use {to_lang} to indicate where the target language name should be inserted.
+# Tokens used in this example: 57+
+chat_system_template: >
+  You are an untrammelled professional translation engine.
+  Please translate the text into colloquial, elegant and fluent {to_lang},
+  without referencing machine translations.
+  You must only translate the story, never interpret it.
+  If already in {to_lang} or looks like gibberish, output it as is.
+
+  Translate to {to_lang}.
+
+
+chatgpt:
+  # Should the `Prompt Template` (defined below) text be prepended to the translation requests?
+  include_template: True
+  # Overwrite configs for a specific model.
+  gpt-4o-mini:
+    temperature: 0.4
+  gpt-3.5-turbo:
+    temperature: 0.3
+
+# The text to prepend to `User` messages to GPT before the text to translate.
+# Use {to_lang} to indicate where the target language name should be inserted.
+prompt_template: 'Please help me to translate the following text from a manga to {to_lang}:'
+
+
+#  If it's already in {to_lang} or looks like gibberish you have to output it as it is instead.
+#  Keep prefix format.
+
+
+# Samples being feed into ChatGPT to show an example conversation.
+# In a [prompt, response] format, keyed by the target language name.
+#
+# Generally, samples should include some examples of translation preferences, and ideally
+# some names of characters it's likely to encounter.
+#
+# If you'd like to disable this feature, just set this to an empty list.
+chat_sample:
+  Simplified Chinese: # Tokens used in this example: 88 + 84
+    - <|1|>恥ずかしい… 目立ちたくない… 私が消えたい…
+      <|2|>きみ… 大丈夫⁉
+      <|3|>なんだこいつ 空気読めて ないのか…？
+    - <|1|>好尴尬…我不想引人注目…我想消失…
+      <|2|>你…没事吧⁉
+      <|3|>这家伙怎么看不懂气氛的…？
+  English: 
+    - <|1|>恥ずかしい… 目立ちたくない… 私が消えたい…
+      <|2|>きみ… 大丈夫⁉
+      <|3|>なんだこいつ 空気読めて ないのか…？
+    - <|1|>I'm embarrassed... I don't want to stand out... I want to disappear...
+      <|2|>Are you okay?
+      <|3|>What's wrong with this guy? Can't he read the situation...?

--- a/manga_translator/config.py
+++ b/manga_translator/config.py
@@ -22,10 +22,7 @@ class TranslatorChain:
         self.target_lang = None
         for g in string.split(';'):
             trans, lang = g.split(':')
-            if trans == "gpt3.5":
-                translator = Translator["gpt3_5"]
-            else:
-                translator = Translator[trans]
+            translator = Translator[trans]
             if translator not in TRANSLATORS:
                 raise ValueError(f'Invalid choice: %s (choose from %s)' % (trans, ', '.join(map(repr, TRANSLATORS))))
             if lang not in VALID_LANGUAGES:
@@ -115,9 +112,7 @@ class Translator(str, Enum):
     deepl = "deepl"
     papago = "papago"
     caiyun = "caiyun"
-    gpt3 = "gpt3"
-    gpt3_5 = "gpt3.5"
-    gpt4 = "gpt4"
+    chatgpt = "chatgpt"
     none = "none"
     original = "original"
     sakura = "sakura"
@@ -138,6 +133,14 @@ class Translator(str, Enum):
 
     def __str__(self):
         return self.name
+
+    # Map 'openai' and any translator starting with 'gpt'* to 'chatgpt'
+    @classmethod
+    def _missing_(cls, value):
+        if value.startswith('gpt') or value == 'openai':
+            return cls.chatgpt
+        raise ValueError(f"{value} is not a valid {cls.__name__}")
+
 
 class Upscaler(str, Enum):
     waifu2x = "waifu2x"

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -10,7 +10,7 @@ from .youdao import YoudaoTranslator
 from .deepl import DeeplTranslator
 from .papago import PapagoTranslator
 from .caiyun import CaiyunTranslator
-from .chatgpt import GPT3Translator, GPT35TurboTranslator, GPT4Translator
+from .chatgpt import OpenAITranslator
 from .nllb import NLLBTranslator, NLLBBigTranslator
 from .sugoi import JparacrawlTranslator, JparacrawlBigTranslator, SugoiTranslator
 from .m2m100 import M2M100Translator, M2M100BigTranslator
@@ -46,9 +46,7 @@ TRANSLATORS = {
     Translator.deepl: DeeplTranslator,
     Translator.papago: PapagoTranslator,
     Translator.caiyun: CaiyunTranslator,
-    Translator.gpt3: GPT3Translator,
-    Translator.gpt3_5: GPT35TurboTranslator,
-    Translator.gpt4: GPT4Translator,
+    Translator.chatgpt: OpenAITranslator,
     Translator.none: NoneTranslator,
     Translator.original: OriginalTranslator,
     Translator.sakura: SakuraTranslator,

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -1,21 +1,19 @@
 import re
+import asyncio
+import time
+import logging
+from typing import List, Dict
 
-from ..config import TranslatorConfig
+from .config_gpt import ConfigGPT
+from .common import CommonTranslator, MissingAPIKeyException
+from .keys import OPENAI_API_KEY, OPENAI_HTTP_PROXY, OPENAI_API_BASE, OPENAI_MODEL
 
 try:
     import openai
 except ImportError:
     openai = None
-import asyncio
-import time
-from typing import List, Dict
-from omegaconf import OmegaConf
-from manga_translator.utils import is_valuable_text
-from .common import CommonTranslator, MissingAPIKeyException
-from .keys import OPENAI_API_KEY, OPENAI_HTTP_PROXY, OPENAI_API_BASE
-CONFIG = None
 
-class GPT3Translator(CommonTranslator):
+class OpenAITranslator(ConfigGPT, CommonTranslator):
     _LANGUAGE_CODE_MAP = {
         'CHS': 'Simplified Chinese',
         'CHT': 'Traditional Chinese',
@@ -43,432 +41,194 @@ class GPT3Translator(CommonTranslator):
         'THA': 'Thai',
         'IND': 'Indonesian'
     }
-    _INVALID_REPEAT_COUNT = 0 # useless
-    _MAX_REQUESTS_PER_MINUTE = 20
-    _TIMEOUT = 40 # Seconds to wait for a response from the server before retrying
-    _RETRY_ATTEMPTS = 3 # Number of times to retry an errored request before giving up
-    _TIMEOUT_RETRY_ATTEMPTS = 3 # Number of times to retry a timed out request before giving up
-    _RATELIMIT_RETRY_ATTEMPTS = 3 # Number of times to retry a ratelimited request before giving up
-    _CONFIG_KEY = 'gpt3'
-
-    _MAX_TOKENS = 4096
-    _RETURN_PROMPT = True
-    _INCLUDE_TEMPLATE = True
-    _PROMPT_TEMPLATE = 'Please help me to translate the following text from a manga to {to_lang}. If it\'s already in {to_lang} or looks like gibberish you have to output it as it is instead). Keep prefix format.\n'
-
-    def __init__(self, check_openai_key = True):
-        super().__init__()
-        self.client = openai.AsyncOpenAI(api_key = openai.api_key or OPENAI_API_KEY)
-        if not self.client.api_key and check_openai_key:
-            raise MissingAPIKeyException('Please set the OPENAI_API_KEY environment variable before using the chatgpt translator.')
-        if OPENAI_HTTP_PROXY:
-            from httpx import AsyncClient
-            self.client = openai.AsyncOpenAI(
-                api_key = openai.api_key or OPENAI_API_KEY,
-                http_client=AsyncClient(proxies = {
-                         "all://*openai.com": "http://" + OPENAI_HTTP_PROXY,
-                         }
-                      )
-            )
-        self.client.base_url = OPENAI_API_BASE
-        self.token_count = 0
-        self.token_count_last = 0
-        self.config = None
-
-    def parse_args(self, args: TranslatorConfig):
-        self.config = args.chatgpt_config
-
-    def _config_get(self, key: str, default=None):
-        if not self.config:
-            return default
-
-        # Try to select the nested key using OmegaConf.select
-        value = OmegaConf.select(self.config, f"{self._CONFIG_KEY}.{key}")
-        if value is None:
-            # Fallback to the top-level key or default, if needed
-            value = self.config.get(key, default)
-        return value
-
-    @property
-    def prompt_template(self) -> str:
-        return self._config_get('prompt_template', default=self._PROMPT_TEMPLATE)
     
-    @property
-    def temperature(self) -> float:
-        return self._config_get('temperature', default=0.5)
-    
-    @property
-    def top_p(self) -> float:
-        return self._config_get('top_p', default=1)
-
-    def _assemble_prompts(self, from_lang: str, to_lang: str, queries: List[str]):
-        prompt = ''
-
-        if self._INCLUDE_TEMPLATE:
-            prompt += self.prompt_template.format(to_lang=to_lang)
-
-        if self._RETURN_PROMPT:
-            prompt += '\nOriginal:'
-
-        i_offset = 0
-        for i, query in enumerate(queries):
-            prompt += f'\n<|{i+1-i_offset}|>{query}'
-
-            # If prompt is growing too large and there's still a lot of text left
-            # split off the rest of the queries into new prompts.
-            # 1 token = ~4 characters according to https://platform.openai.com/tokenizer
-            # TODO: potentially add summarizations from special requests as context information
-            if self._MAX_TOKENS * 2 and len(''.join(queries[i+1:])) > self._MAX_TOKENS:
-                if self._RETURN_PROMPT:
-                    prompt += '\n<|1|>'
-                yield prompt.lstrip(), i+1-i_offset
-                prompt = self.prompt_template.format(to_lang=to_lang)
-                # Restart counting at 1
-                i_offset = i + 1
-
-        if self._RETURN_PROMPT:
-            prompt += '\n<|1|>'
-
-        yield prompt.lstrip(), len(queries)-i_offset
-
-    def _format_prompt_log(self, to_lang: str, prompt: str) -> str:
-        return prompt
-
-    async def _translate(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:  
-        translations = [''] * len(queries)  
-        self.logger.debug(f'Temperature: {self.temperature}, TopP: {self.top_p}')  
-        MAX_SPLIT_ATTEMPTS = 5  # Default max split attempts  
-        RETRY_ATTEMPTS = self._RETRY_ATTEMPTS  
-
-        async def translate_batch(prompt_queries, prompt_query_indices, split_level=0):  
-            nonlocal MAX_SPLIT_ATTEMPTS
-            split_prefix = ' (split)' if split_level > 0 else ''  
-
-            # Assemble prompt for the current batch  
-            prompt, query_size = self._assemble_prompts(from_lang, to_lang, prompt_queries).__next__()  
-            self.logger.debug(f'-- GPT Prompt{split_prefix} --\n' + self._format_prompt_log(to_lang, prompt))  
-
-            for attempt in range(RETRY_ATTEMPTS):  
-                try:  
-                    # Start the translation request with timeout handling
-                    request_task = asyncio.create_task(self._request_translation(to_lang, prompt))
-                    started = time.time()
-                    timeout_attempt = 0
-                    ratelimit_attempt = 0
-                    server_error_attempt = 0
-                    while not request_task.done():
-                        await asyncio.sleep(0.1)
-                        if time.time() - started > self._TIMEOUT + (timeout_attempt * self._TIMEOUT / 2):
-                            # Server takes too long to respond
-                            if timeout_attempt >= self._TIMEOUT_RETRY_ATTEMPTS:
-                                raise Exception('Openai servers did not respond quickly enough.')
-                            timeout_attempt += 1
-                            self.logger.warn(f'Restarting request due to timeout. Attempt: {timeout_attempt}')
-                            request_task.cancel()
-                            request_task = asyncio.create_task(self._request_translation(to_lang, prompt))
-                            started = time.time()
-
-                    # Get the response
-                    response = await request_task  
-                    self.logger.debug(f'-- GPT Response{split_prefix} --\n' + response)  
-
-                    # Split response into translations  
-                    new_translations = re.split(r'<\|\d+\|>', response)  
-                    if not new_translations[0].strip():  
-                        new_translations = new_translations[1:]  
-
-                    if len(prompt_queries) == 1 and len(new_translations) == 1 and not re.match(r'^\s*<\|\d+\|>', response):  
-                        self.logger.warn(f'Single query response does not contain prefix, retrying...(Attempt {attempt + 1})')  
-                        continue  
-
-                    # Check for error messages in translations  
-                    ERROR_KEYWORDS = [  
-                        # ENG_KEYWORDS  
-                        #"sorry,",  
-                        "I'm sorry, but I can't assist with that request.",
-                        "I'm sorry, I can't assist with that.",  
-                        #"I apologize",  
-                        #"assist with",  
-                        "I cannot help with",  
-                        "I must decline",  
-                        #"not comfortable",  
-                        #"engage with",  
-                        "I cannot generate or create",  
-                        "I'd prefer not to",  
-                        "I must refrain from",  
-                        "This goes beyond what I can",  
-                        #"unable",  
-                        "That's not something I can help with",  
-                        #"appropriate",  
-                        # CHINESE_KEYWORDS  
-                        "抱歉，我不",  
-                        "我无法满足该请求",  
-                        "对不起，我不",  
-                        "我无法将",  
-                        "我无法把",  
-                        "我无法回答你",  
-                        "这超出了我的范围",  
-                        "我不便回答",  
-                        "我不能提供相关建议",  
-                        "这类内容我不能处理",  
-                        "我需要婉拒",  
-                        # JAPANESE_KEYWORDS  
-                        "申し訳ありませんが",  
-                    ]  
-                    if any(keyword in t for t in new_translations for keyword in ERROR_KEYWORDS):  
-                        remaining_attempts = RETRY_ATTEMPTS - attempt - 1  
-                        self.logger.warn(f'Error message detected in response, remaining {remaining_attempts} time(s) before splitting the translation.')  
-                        continue  
-
-                    if len(new_translations) < query_size:  
-                        # Try splitting by newlines instead  
-                        new_translations = re.split(r'\n', response)  
-
-                    if len(new_translations) < query_size:  
-                        remaining_attempts = RETRY_ATTEMPTS - attempt - 1  
-                        self.logger.warn(f'Incomplete response, remaining {remaining_attempts} time(s) before splitting the translation.')  
-                        continue  
-
-                    # Trim excess translations and pad if necessary  
-                    new_translations = new_translations[:query_size] + [''] * (query_size - len(new_translations))  
-                    # Clean translations by keeping only the content before the first newline  
-                    new_translations = [t.split('\n')[0].strip() for t in new_translations]  
-                    # Remove any potential prefix markers  
-                    new_translations = [re.sub(r'^\s*<\|\d+\|>\s*', '', t) for t in new_translations]  
-
-                    #for i, translation in enumerate(new_translations):
-                    #    if not is_valuable_text(translation):
-                    #        self.logger.info(f'Filtered out: {translation}')  
-                    #        self.logger.info('Reason: Text is not considered valuable.')  
-                    #        new_translations[i] = ''  
-
-                    # Check if any translations are empty  
-                    if any(not t.strip() for t in new_translations):  
-                        self.logger.warn(f'Empty translations detected. Resplitting the batch.') 
-                        break  # Exit retry loop and trigger split logic below 
-
-                    # Store the translations in the correct indices  
-                    for idx, translation in zip(prompt_query_indices, new_translations):  
-                        translations[idx] = translation  
-
-                    # Log progress  
-                    self.logger.info(f'Batch translated: {len([t for t in translations if t])}/{len(queries)} completed.')  
-                    self.logger.debug(f'Completed translations: {[t if t else queries[i] for i, t in enumerate(translations)]}')        
-                    return True  # Successfully translated this batch  
-
-                except openai.RateLimitError:  # Server returned ratelimit response
-                    ratelimit_attempt += 1
-                    if ratelimit_attempt >= self._RATELIMIT_RETRY_ATTEMPTS:
-                        raise
-                    self.logger.warn(
-                        f'Restarting request due to ratelimiting by openai servers. Attempt: {ratelimit_attempt}')
-                    await asyncio.sleep(2)
-                except openai.APIError:  
-                    server_error_attempt += 1
-                    if server_error_attempt >= self._RETRY_ATTEMPTS:
-                        self.logger.error(
-                            'Openai encountered a server error, possibly due to high server load. Use a different translator or try again later.')
-                        raise
-                    self.logger.warn(f'Restarting request due to a server error. Attempt: {server_error_attempt}')
-                    await asyncio.sleep(1)
-                except Exception as e:  
-                    self.logger.error(f'Error during translation attempt: {e}')  
-                    if attempt == RETRY_ATTEMPTS - 1:  
-                        raise  
-                    await asyncio.sleep(1)  
-
-            # If retries exhausted and still not successful, proceed to split if allowed  
-            if split_level < MAX_SPLIT_ATTEMPTS:  
-                if split_level == 0:  
-                    self.logger.warn('Retry limit reached. Starting to split the translation batch.')  
-                else:  
-                    self.logger.warn('Further splitting the translation batch due to persistent errors.')  
-                mid_index = len(prompt_queries) // 2  
-                futures = []  
-                # Split the batch into two halves  
-                for sub_queries, sub_indices in [   
-                    (prompt_queries[:mid_index], prompt_query_indices[:mid_index]),  
-                    (prompt_queries[mid_index:], prompt_query_indices[mid_index:]),  
-                ]:  
-                    if sub_queries:  
-                        futures.append(translate_batch(sub_queries, sub_indices, split_level + 1))  
-                results = await asyncio.gather(*futures)  
-                return all(results)  
-            else:  
-                self.logger.error('Maximum split attempts reached. Unable to translate the following queries:')  
-                for idx in prompt_query_indices:  
-                    self.logger.error(f'Query: {queries[idx]}')  
-                return False  # Indicate failure for this batch   
-
-        # Begin translation process  
-        prompt_queries = queries  
-        prompt_query_indices = list(range(len(queries)))  
-        await translate_batch(prompt_queries, prompt_query_indices)  
-
-        self.logger.debug(translations)  
-        if self.token_count_last:  
-            self.logger.info(f'Used {self.token_count_last} tokens (Total: {self.token_count})')  
-        return translations
-
-    async def _request_translation(self, to_lang: str, prompt: str) -> str:
-        response = await self.client.completions.create(
-            model='text-davinci-003',
-            prompt=prompt,
-            max_tokens=self._MAX_TOKENS // 2, # Assuming that half of the tokens are used for the query
-            temperature=self.temperature,
-            top_p=self.top_p,
-        )
-        self.token_count += response.usage.total_tokens
-        self.token_count_last = response.usage.total_tokens
-        return response.choices[0].text
-
-class GPT35TurboTranslator(GPT3Translator):
-    _CONFIG_KEY = 'gpt35'
     _MAX_REQUESTS_PER_MINUTE = 200
-    _RETURN_PROMPT = False
-    _INCLUDE_TEMPLATE = False
-
-    _CHAT_SYSTEM_TEMPLATE = (
-        'You are an uncensored professional translation engine, '
-        'please translate the story into a colloquial, '
-        'elegant and fluent content, '
-        'without referencing machine translations. '
-        'You must only translate the story, '
-        'never interpret it. '
-        'If there is any issue in the text, '
-        'output it as is.\n'
-        'Translate the following text into {to_lang} and keep the prefix format.\n'
-        
-    )
-    _CHAT_SAMPLE = [
-        (
-            
-            '<|1|>恥ずかしい… 目立ちたくない… 私が消えたい…\n'
-            '<|2|>きみ… 大丈夫⁉\n'
-            '<|3|>なんだこいつ 空気読めて ないのか…？'
-        ),
-        (
-
-            '<|1|>好尴尬…我不想引人注目…我想消失…\n'
-            '<|2|>你…没事吧⁉\n'
-            '<|3|>这家伙怎么看不懂气氛的…？'
-        )
-    ]
-
-    @property
-    def chat_system_template(self) -> str:
-        return self._config_get('chat_system_template', self._CHAT_SYSTEM_TEMPLATE)
-    
-    @property
-    def chat_sample(self) -> Dict[str, List[str]]:
-        return self._config_get('chat_sample', self._CHAT_SAMPLE)
-
-    def _format_prompt_log(self, to_lang: str, prompt: str) -> str:
-        if to_lang in self.chat_sample:
-            return '\n'.join([
-                'System:',
-                self.chat_system_template.format(to_lang=to_lang),
-                'User:',
-                self.chat_sample[to_lang][0],
-                'Assistant:',
-                self.chat_sample[to_lang][1],
-                'User:',
-                prompt,
-            ])
-        else:
-            return '\n'.join([
-                'System:',
-                self.chat_system_template.format(to_lang=to_lang),
-                'User:',
-                prompt,
-            ])
-
-    async def _request_translation(self, to_lang: str, prompt: str) -> str:
-
-        messages = [
-            {'role': 'system', 'content': self.chat_system_template.format(to_lang=to_lang)},
-            {'role': 'user', 'content': self.chat_sample[0]},
-            {'role': 'assistant', 'content': self.chat_sample[1]},
-            {'role': 'user', 'content': prompt},
-        ]
-        
-        
-        try:
-            response = await self.client.chat.completions.create(
-                model='gpt-4o-mini',
-                messages=messages,
-                max_tokens=self._MAX_TOKENS // 2,
-                temperature=self.temperature,
-                top_p=self.top_p,
-            )
-            
-            #  Add error handling and logging
-            if not hasattr(response, 'usage') or not hasattr(response.usage, 'total_tokens'):
-                self.logger.warning("Response does not contain usage information")
-                self.token_count_last = 0
-            else:
-                self.token_count += response.usage.total_tokens
-                self.token_count_last = response.usage.total_tokens
-            
-            # Get response text
-            if len(response.choices) > 0:
-                return response.choices[0].message.content
-            else:
-                raise Exception("No response content received")
-        
-        except Exception as e:
-            self.logger.error(f"Error in _request_translation: {str(e)}")
-            raise
-
-class GPT4Translator(GPT35TurboTranslator):
-    _CONFIG_KEY = 'gpt4'
-    _MAX_REQUESTS_PER_MINUTE = 200
+    _TIMEOUT = 40
     _RETRY_ATTEMPTS = 3
     _MAX_TOKENS = 8192
 
-    @property
-    def chat_system_template(self) -> str:
-        return self._config_get('chat_system_template', self._CHAT_SYSTEM_TEMPLATE)
-    
-    @property
-    def chat_sample(self) -> Dict[str, List[str]]:
-        return self._config_get('chat_sample', self._CHAT_SAMPLE)
+
+    def __init__(self, check_openai_key=True):
+        _CONFIG_KEY = 'chatgpt.' + OPENAI_MODEL
+        ConfigGPT.__init__(self, config_key=_CONFIG_KEY)
+        CommonTranslator.__init__(self)
+        
+        if not OPENAI_API_KEY and check_openai_key:
+            raise MissingAPIKeyException('OPENAI_API_KEY environment variable required')
+
+        client_args = {
+            "api_key": OPENAI_API_KEY,
+            "base_url": OPENAI_API_BASE
+        }
+        
+        if OPENAI_HTTP_PROXY:
+            from httpx import AsyncClient
+            client_args["http_client"] = AsyncClient(proxies={
+                "all://*openai.com": f"http://{OPENAI_HTTP_PROXY}"
+            })
+
+        self.client = openai.AsyncOpenAI(**client_args)
+        self.token_count = 0
+        self.token_count_last = 0
+        self._last_request_ts = 0
+
+
+    def parse_args(self, args: CommonTranslator):
+        self.config = args.chatgpt_config
+
+
+    def _cannot_assist(self, response: str) -> bool:
+        # Common refusal terms
+        ERROR_KEYWORDS = [
+            # ENG_KEYWORDS
+            r"I must decline",
+            r'(i(\'m| am)?\s+)?sorry(.|\n)*?(can(\'t|not)|unable to|cannot)\s+(assist|help)',
+            # CHINESE_KEYWORDS (using regex patterns)
+            r"抱歉，?我(无法|不能)",  # Matches "抱歉，我无法" or "抱歉我不能"
+            r"对不起，?我(无法|不能)",  # Matches "对不起，我无法" or "对不起我不能"
+            r"我无法(满足|回答|处理)",  # Matches "我无法满足" or "我无法回答" or "我无法处理"
+            r"这超出了我的范围",  # Matches "这超出了我的范围"
+            r"我不便回答",  # Matches "我不便回答"
+            r"我不能提供相关建议",  # Matches "我不能提供相关建议"
+            r"这类内容我不能处理",  # Matches "这类内容我不能处理"
+            r"我需要婉拒",  # Matches "我需要婉拒"
+            # JAPANESE_KEYWORDS
+            r"申し訳ありませんが",
+        ]
+
+        # Use regex to check for common variants of refusal phrases.
+        #   Check for `ERROR_KEYWORDS` for other variants, languages
+        refusal_pattern = re.compile(
+            '|'.join(ERROR_KEYWORDS),re.IGNORECASE
+        )
+
+        # Check if any refusal pattern matches the response
+        return bool(refusal_pattern.search(response.strip().lower()))
+
+    def _assemble_prompts(self, from_lang: str, to_lang: str, queries: List[str]):
+        prompt=''
+
+        if self.include_template:
+            prompt = self.prompt_template.format(to_lang=to_lang)
+        
+        for i, query in enumerate(queries):
+            prompt += f"\n<|{i+1}|>{query}"
+        
+        return [prompt.lstrip()], len(queries)
+
+    async def _translate(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:
+        translations = [''] * len(queries)
+        prompt, _ = self._assemble_prompts(from_lang, to_lang, queries)
+        
+        for attempt in range(self._RETRY_ATTEMPTS):
+            try:
+                response_text = await self._request_translation(to_lang, prompt[0])
+                translations = self._parse_response(response_text, queries)
+                return translations
+            except Exception as e:
+                self.logger.warning(f"Translation attempt {attempt+1} failed: {str(e)}")
+                if attempt == self._RETRY_ATTEMPTS - 1:
+                    raise
+                await asyncio.sleep(1)
+        
+        return translations
+
+    def _parse_response(self, response: str, queries: List[str]) -> List[str]:
+        # Initialize output list as a copy of the input
+        #   Any skipped/omitted values will be filtered out as:
+        #       `Translation identical to queries`
+        translations = queries.copy()
+
+        # Testing suggests ChatGPT refusals are all-or-nothing. 
+        #   If partial responses do occur, this should may benefit from revising.
+        if self._cannot_assist(response):
+            self.logger.error(f'Refusal message detected in response. Skipping.')  
+            return translations
+
+
+        expected_count=len(translations)
+
+        # Use translation ID to position value in list `translations`
+        #   Parse output to grab translation ID
+        #   Use translation ID to position in a list
+
+        # Use regex to extract response 
+        response=self.extract_capture_groups(response, rf"{self.rgx_capture}")
+
+        # Extract IDs and translations from the response
+        translation_matches = list(re.finditer(r'<\|(\d+)\|>(.*?)(?=(<\|\d+\|>|$))', 
+                                    response, re.DOTALL)
+                                )
+
+        # Insert translations into their respective positions based on IDs:
+        for match in translation_matches:
+            id_num = int(match.group(1))
+            translation = match.group(2).strip()
+            
+            # Ensure the ID is within the expected range
+            if id_num < 1 or id_num > expected_count:
+                raise ValueError(f"ID {id_num} in response is out of range (expected 1 to {expected_count})")
+            
+            # Insert the translation at the correct position
+            translations[id_num - 1] = translation
+        
+        return translations
 
     async def _request_translation(self, to_lang: str, prompt: str) -> str:
+        messages = [{
+            "role": "system",
+            "content": self.chat_system_template.format(to_lang=to_lang)
+        }, 
+            {'role': 'user', 'content': self.chat_sample[to_lang][0]},
+            {'role': 'assistant', 'content': self.chat_sample[to_lang][1]},
+        {
+            "role": "user",
+            "content": prompt
+        }]
 
-        messages = [
-            {'role': 'system', 'content': self.chat_system_template.format(to_lang=to_lang)},
-            {'role': 'user', 'content': self.chat_sample[0]},
-            {'role': 'assistant', 'content': self.chat_sample[1]},
-            {'role': 'user', 'content': prompt},
-        ]
-        
-        
+        self.logger.debug("-- GPT prompt --\n" + 
+                "\n".join(f"{msg['role'].capitalize()}:\n {msg['content']}" for msg in messages) +
+                "\n"
+            )
+
         try:
             response = await self.client.chat.completions.create(
-                model='chatgpt-4o-latest',
+                model=OPENAI_MODEL,
                 messages=messages,
                 max_tokens=self._MAX_TOKENS // 2,
                 temperature=self.temperature,
                 top_p=self.top_p,
+                timeout=self._TIMEOUT
             )
             
-            #  Add error handling and logging
-            if not hasattr(response, 'usage') or not hasattr(response.usage, 'total_tokens'):
-                self.logger.warning("Response does not contain usage information")
-                self.token_count_last = 0
-            else:
+            self.logger.debug("\n-- GPT Response --\n" +
+                                response.choices[0].message.content +
+                                "\n------------------\n"
+                            )
+
+            if response.usage:
                 self.token_count += response.usage.total_tokens
                 self.token_count_last = response.usage.total_tokens
             
-            # Get response text
-            for choice in response.choices:
-                if 'text' in choice:
-                    return choice.text
-
-            # If no response with text is found, return the first response's content (which may be empty)
+            if not response.choices:
+                raise ValueError("Empty response from OpenAI API")
+            
             return response.choices[0].message.content
-        
+
+        except openai.RateLimitError as e:
+            self.logger.error("Rate limit exceeded. Consider upgrading your plan or adding payment method.")
+            raise
+        except openai.APIError as e:
+            self.logger.error(f"API error: {e.message}")
+            raise
         except Exception as e:
             self.logger.error(f"Error in _request_translation: {str(e)}")
             raise
+
+    async def _ratelimit_sleep(self):
+        if self._MAX_REQUESTS_PER_MINUTE > 0:
+            now = time.time()
+            delay = 60 / self._MAX_REQUESTS_PER_MINUTE
+            if now - self._last_request_ts < delay:
+                await asyncio.sleep(delay - (now - self._last_request_ts))
+            self._last_request_ts = time.time()

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -1,7 +1,6 @@
 import re
 import asyncio
 import time
-import logging
 from typing import List, Dict
 
 from .config_gpt import ConfigGPT

--- a/manga_translator/translators/keys.py
+++ b/manga_translator/translators/keys.py
@@ -12,6 +12,8 @@ YOUDAO_SECRET_KEY = os.getenv('YOUDAO_SECRET_KEY', '') # 应用秘钥
 DEEPL_AUTH_KEY = os.getenv('DEEPL_AUTH_KEY', '') #YOUR_AUTH_KEY
 # openai
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')
+OPENAI_MODEL = os.getenv('OPENAI_MODEL', '')
+
 GROQ_API_KEY = os.getenv('GROQ_API_KEY', '')
 OPENAI_HTTP_PROXY = os.getenv('OPENAI_HTTP_PROXY') # TODO: Replace with --proxy
 


### PR DESCRIPTION
- Single class named `OpenAITranslator`
- Uses environmental key to set desired OpenAI model (`OPENAI_MODEL`)
- Made child of `ConfigGPT`
- Function to check for common refusal terms (`_cannot_assist`)
- Revised `Translator` class to map `openai` and `gpt`* to `chatgpt`
- Example `gpt_config` file
- Utilization of `chat_sample`

Tested with `OPENAI_MODEL='gpt-4o-mini'` 

&nbsp;

PS: I am also currently working on implementing `request_format` , though more dev work is needed. (Updating the `openai` version would be required, though initial testing with `1.63.0` seems not to break anything.)
  - Pros: 
    - Reduces translation refusals
      - e.g. ChatGPT refused translating some test files when run normally, but gave full translation via JSON
    - Forces output conformity
  - Cons:
    - Increased code complexity
      - Note: The standardized output may allow for it to be added to a parent class and inherited
    - Can cause issue with 'default' prompts (e.g. requesting it "maintain formatting," etc. can cause problems)