### PR TITLE
PaddleOCR - Check for `None` result

### DIFF
--- a/manga_translator/detection/paddle.py
+++ b/manga_translator/detection/paddle.py
@@ -90,7 +90,6 @@ class PaddleDetector(OfflineDetector, ModelWrapper):
 
         # Check for `None` result
         # - Seems to occur in rare edge-case scenarios
-        #   (encountered when only text on page was '.....?')
         if result[0] is not None:
             # Parse OCR results and filter by text threshold
             for line in result[0]:


### PR DESCRIPTION
Minor change - catch rare `None` value for `result[0]`.  
(Seems to occur in rare edge-case scenarios - e.g. when only text on page was `........?`)

1. Moved OCR parsing inside `if result[0] is not None`
2. If `None`, returned values:
    - `textlines=[]`
    - `mask=np.zeros(...)`
3. Handled downstream as: `No text regions! - Skipping`