### PR TITLE
use paddlepaddle instead of  paddlepaddle-gpu on macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Scripts
 Lib
 include
 share
+.DS_Store
 
 # Distribution / packaging
 .Python

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,4 +55,5 @@ fastapi
 pydantic
 python-multipart
 paddleocr
-paddlepaddle-gpu
+paddlepaddle; sys_platform == 'darwin'
+paddlepaddle-gpu; sys_platform != 'darwin'


### PR DESCRIPTION
Fix for #855. 

Now we install the CPU version of the PaddlePaddle (the `paddlepaddle` package) on macOS instead of the GPU one (the `paddlepaddle-gpu` package).