### PR TITLE
让Translator chain可以运行

### DIFF
--- a/examples/translator_chain_example.json
+++ b/examples/translator_chain_example.json
@@ -1,0 +1,61 @@
+{
+  "filter_text": null,
+  "render": {
+    "renderer": "default",
+    "alignment": "auto",
+    "disable_font_border": false,
+    "font_size_offset": 0,
+    "font_size_minimum": -1,
+    "direction": "auto",
+    "uppercase": false,
+    "lowercase": false,
+    "gimp_font": "Sans-serif",
+    "no_hyphenation": false,
+    "font_color": null,
+    "line_spacing": null,
+    "font_size": null
+  },
+  "upscale": {
+    "upscaler": "esrgan",
+    "revert_upscaling": false,
+    "upscale_ratio": null
+  },
+  "translator": {
+    "translator": "offline",
+    "target_lang": "CHS",
+    "no_text_lang_skip": false,
+    "skip_lang": null,
+    "gpt_config": null,
+    "translator_chain": "sugoi:ENG;papago:CHS",
+    "selective_translation": null
+  },
+  "detector": {
+    "detector": "ctd",
+    "detection_size": 1536,
+    "text_threshold": 0.5,
+    "det_rotate": false,
+    "det_auto_rotate": false,
+    "det_invert": false,
+    "det_gamma_correct": false,
+    "box_threshold": 0.7,
+    "unclip_ratio": 2.3
+  },
+  "colorizer": {
+    "colorization_size": 576,
+    "denoise_sigma": 30,
+    "colorizer": "none"
+  },
+  "inpainter": {
+    "inpainter": "none",
+    "inpainting_size": 2048,
+    "inpainting_precision": "fp32"
+  },
+  "ocr": {
+    "use_mocr_merge": false,
+    "ocr": "48px",
+    "min_text_length": 0,
+    "ignore_bubble": 0
+  },
+  "kernel_size": 3,
+  "mask_dilation_offset": 0
+}

--- a/manga_translator/config.py
+++ b/manga_translator/config.py
@@ -236,7 +236,7 @@ class TranslatorConfig(BaseModel):
                 self._translator_gen = trans
             elif self.translator_chain is not None:
                 trans = translator_chain(self.translator_chain)
-                trans.target_lang = trans.langs[-1]
+                trans.target_lang = trans.langs[0]
                 self._translator_gen = trans
             else:
                 self._translator_gen = TranslatorChain(f'{str(self.translator)}:{self.target_lang}')

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -82,17 +82,19 @@ async def dispatch(chain: TranslatorChain, queries: List[str], translator_config
     if chain.target_lang is not None:
         text_lang = ISO_639_1_TO_VALID_LANGUAGES.get(langid.classify('\n'.join(queries))[0])
         translator = None
-        for key, lang in chain.chain:
-            if text_lang == lang:
-                translator = get_translator(key)
-                break
-        if translator is None:
-            translator = get_translator(chain.langs[0])
-        if isinstance(translator, OfflineTranslator):
-            await translator.load('auto', chain.target_lang, device)
-        if translator_config:
-            translator.parse_args(translator_config)
-        queries = await translator.translate('auto', chain.target_lang, queries, use_mtpe)
+        flag=0
+        for key, lang in chain.chain:           
+            #if text_lang == lang:
+                #translator = get_translator(key)
+            #if translator is None:
+            translator = get_translator(chain.translators[flag])
+            if isinstance(translator, OfflineTranslator):
+                await translator.load('auto', chain.langs[flag], device)
+                pass
+            if translator_config:
+                translator.parse_args(translator_config)
+            queries = await translator.translate('auto', chain.langs[flag], queries, use_mtpe)
+            flag+=1
         return queries
     if args is not None:
         args['translations'] = {}

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -94,7 +94,7 @@ async def dispatch(chain: TranslatorChain, queries: List[str], translator_config
             if translator_config:
                 translator.parse_args(translator_config)
             queries = await translator.translate('auto', chain.langs[flag], queries, use_mtpe)
-            await translator.unload(device)
+            await translator.unload()
             flag+=1
         return queries
     if args is not None:

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -94,7 +94,7 @@ async def dispatch(chain: TranslatorChain, queries: List[str], translator_config
             if translator_config:
                 translator.parse_args(translator_config)
             queries = await translator.translate('auto', chain.langs[flag], queries, use_mtpe)
-            await translator.unload()
+            await translator.unload(device)
             flag+=1
         return queries
     if args is not None:

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -94,6 +94,7 @@ async def dispatch(chain: TranslatorChain, queries: List[str], translator_config
             if translator_config:
                 translator.parse_args(translator_config)
             queries = await translator.translate('auto', chain.langs[flag], queries, use_mtpe)
+            await translator.unload(device)
             flag+=1
         return queries
     if args is not None:

--- a/manga_translator/translators/common.py
+++ b/manga_translator/translators/common.py
@@ -319,3 +319,10 @@ class OfflineTranslator(CommonTranslator, ModelWrapper):
 
     async def reload(self, from_lang: str, to_lang: str, device: str):
         return await super().reload(device, from_lang, to_lang)
+    
+    @abstractmethod
+    async def _load(self, from_lang: str, to_lang: str, device: str):
+        pass
+
+    async def unload(self, device: str):
+        return await super().unload(device)

--- a/manga_translator/translators/common.py
+++ b/manga_translator/translators/common.py
@@ -325,4 +325,4 @@ class OfflineTranslator(CommonTranslator, ModelWrapper):
         pass
 
     async def unload(self, device: str):
-        return await super().unload(device)
+        return await super().unload()


### PR DESCRIPTION
修改了一些代码，让Translator chain可以运行
config:
```
{
  "filter_text": null,
  "render": {
    "renderer": "default",
    "alignment": "auto",
    "disable_font_border": false,
    "font_size_offset": 0,
    "font_size_minimum": -1,
    "direction": "auto",
    "uppercase": false,
    "lowercase": false,
    "gimp_font": "Sans-serif",
    "no_hyphenation": false,
    "font_color": null,
    "line_spacing": null,
    "font_size": null
  },
  "upscale": {
    "upscaler": "esrgan",
    "revert_upscaling": false,
    "upscale_ratio": null
  },
  "translator": {
    "translator": "offline",
    "target_lang": "CHS",
    "no_text_lang_skip": false,
    "skip_lang": null,
    "gpt_config": null,
    "translator_chain": "sugoi:ENG;offline:CHS",
    "selective_translation": null
  },
  "detector": {
    "detector": "ctd",
    "detection_size": 1536,
    "text_threshold": 0.5,
    "det_rotate": false,
    "det_auto_rotate": false,
    "det_invert": false,
    "det_gamma_correct": false,
    "box_threshold": 0.7,
    "unclip_ratio": 2.3
  },
  "colorizer": {
    "colorization_size": 576,
    "denoise_sigma": 30,
    "colorizer": "none"
  },
  "inpainter": {
    "inpainter": "none",
    "inpainting_size": 2048,
    "inpainting_precision": "fp32"
  },
  "ocr": {
    "use_mocr_merge": false,
    "ocr": "48px",
    "min_text_length": 0,
    "ignore_bubble": 0
  },
  "kernel_size": 3,
  "mask_dilation_offset": 0
}

```

控制台输出：
```
(sstra) root@hello:~/manga-image-translator# python -m manga_translator local -v -i ./img --config config-example.json
[local] Namespace(verbose=True, attempts=0, ignore_errors=False, model_dir=None, use_gpu=False, use_gpu_limited=False, font_path='', pre_dict=None, post_dict=None, kernel_size=3, mode='local', input=['./img'], dest='', format=None, overwrite=False, skip_no_text=False, use_mtpe=False, save_text=False, load_text=False, save_text_file='', prep_manual=False, save_quality=100, config_file='config-example.json')
[local] Running in local mode
[local] Loading models
[local] Running text detection
[local] Running ocr
[Model48pxOCR] prob: 0.9998793601989746 はい fg: (2, 0, 0) bg: (2, 0, 0)
[Model48pxOCR] prob: 0.999897837638855 はい fg: (0, 0, 0) bg: (0, 0, 0)
[Model48pxOCR] prob: 0.9999887943267822 これは fg: (2, 0, 0) bg: (2, 0, 0)
[Model48pxOCR] prob: 0.9999556541442871 前の話 fg: (0, 0, 0) bg: (0, 0, 0)
[Model48pxOCR] prob: 0.9998542070388794 出会う fg: (3, 3, 1) bg: (3, 3, 1)
[Model48pxOCR] prob: 0.999981164932251 それでは fg: (0, 0, 0) bg: (0, 0, 0)
[Model48pxOCR] prob: 0.9998564720153809 よろしく fg: (1, 3, 0) bg: (1, 3, 0)
[Model48pxOCR] prob: 0.9998773336410522 中野さん fg: (0, 0, 0) bg: (0, 0, 0)
[Model48pxOCR] prob: 0.9997475743293762 中野さんが fg: (0, 1, 0) bg: (0, 1, 0)
[Model48pxOCR] prob: 0.9999098777770996 次の派遣先 fg: (1, 1, 0) bg: (1, 1, 0)
[Model48pxOCR] prob: 0.9985542297363281 山田くんと fg: (1, 1, 0) bg: (1, 1, 0)
[Model48pxOCR] prob: 0.9997466206550598 いただきます fg: (1, 2, 0) bg: (1, 2, 0)
[Model48pxOCR] prob: 0.9998986721038818 お願いします fg: (0, 1, 0) bg: (0, 1, 0)
[Model48pxOCR] prob: 0.9997708201408386 またご連絡させて fg: (0, 0, 0) bg: (0, 0, 0)
[local] No pre-translation replacements made.
[local] Running text translation
[SugoiTranslator] Translating into English
[SugoiTranslator] 0: 前の話 => That was a long time ago.
[SugoiTranslator] 1: 山田くんと出会う => Meet Yamada-kun
[SugoiTranslator] 2: これは中野さんが => This is because nakanosan
[SugoiTranslator] 3: それでは中野さん => Well then, nakanosan.
[SugoiTranslator] 4: 次の派遣先またご連絡させていただきます => I'll be in touch with your next dispatch.
[SugoiTranslator] 5: はい => Yes, sir.
[SugoiTranslator] 6: はい => Yes, sir.
[SugoiTranslator] 7: よろしくお願いします => I look forward to working with you.
[SelectiveOfflineTranslator] Selected translator: M2M100BigTranslator
[M2M100BigTranslator] Translating into Chinese (Simplified)
[M2M100BigTranslator] 0: That was a long time ago. => 那是很久以前的。
[M2M100BigTranslator] 1: Meet Yamada-kun => 与Yamada-kun相遇
[M2M100BigTranslator] 2: This is because nakanosan => 這是因為Nakanosan
[M2M100BigTranslator] 3: Well then, nakanosan. => 好吧, 可惜了。
[M2M100BigTranslator] 4: I'll be in touch with your next dispatch. => 我会与你的下一个发送联系。
[M2M100BigTranslator] 5: Yes, sir. => 是的, 先生。
[M2M100BigTranslator] 6: Yes, sir. => 是的, 先生。
[M2M100BigTranslator] 7: I look forward to working with you. => 我期待着与您合作。
[local] No post-translation replacements made.
[local] Running mask refinement
[mask]: 100%|███████████████████████████████████| 14/14 [00:00<00:00, 71.53it/s]
[local] Running rendering
[render] font_size_minimum 30
[render]: 100%|███████████████████████████████████| 8/8 [00:00<00:00, 12.82it/s]
```
原图：
![03](https://github.com/user-attachments/assets/b2e6ceca-4807-40c3-8b3a-ef3b709e6867)
处理后：
![04](https://github.com/user-attachments/assets/26c01ff8-cb14-49fe-8c25-0276e9e26c30)
