### PR TITLE
rename wrongly labeled module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,41 +14,41 @@
 Some manga/images will never be translated, therefore this project is born.
 
 - [Image/Manga Translator](#imagemanga-translator)
-  - [Samples](#samples)
-  - [Online Demo](#online-demo)
-  - [Disclaimer](#disclaimer)
-  - [Installation](#installation)
-    - [Local setup](#local-setup)
-      - [Pip/venv](#pipvenv)
-      - [Additional instructions for **Windows**](#additional-instructions-for-windows)
-    - [Docker](#docker)
-      - [Hosting the web server](#hosting-the-web-server)
-      - [Using as CLI](#using-as-cli)
-      - [Setting Translation Secrets](#setting-translation-secrets)
-      - [Using with Nvidia GPU](#using-with-nvidia-gpu)
-      - [Building locally](#building-locally)
-  - [Usage](#usage)
-    - [Batch mode (default)](#batch-mode-default)
-    - [Demo mode](#demo-mode)
-    - [Web Mode](#web-mode)
-    - [Api Mode](#api-mode)
-  - [Related Projects](#related-projects)
-  - [Docs](#docs)
-    - [Recommended Modules](#recommended-modules)
-      - [Tips to improve translation quality](#tips-to-improve-translation-quality)
-    - [Options](#options)
-    - [Language Code Reference](#language-code-reference)
-    - [Translators Reference](#translators-reference)
-    - [Config Documentation](#config-file)
-    - [GPT Config Reference](#gpt-config-reference)
-    - [Using Gimp for rendering](#using-gimp-for-rendering)
-    - [Api Documentation](#api-documentation)
-      - [Synchronous mode](#synchronous-mode)
-      - [Asynchronous mode](#asynchronous-mode)
-      - [Manual translation](#manual-translation)
-  - [Next steps](#next-steps)
-  - [Support Us](#support-us)
-    - [Thanks To All Our Contributors :](#thanks-to-all-our-contributors-)
+    - [Samples](#samples)
+    - [Online Demo](#online-demo)
+    - [Disclaimer](#disclaimer)
+    - [Installation](#installation)
+        - [Local setup](#local-setup)
+            - [Pip/venv](#pipvenv)
+            - [Additional instructions for **Windows**](#additional-instructions-for-windows)
+        - [Docker](#docker)
+            - [Hosting the web server](#hosting-the-web-server)
+            - [Using as CLI](#using-as-cli)
+            - [Setting Translation Secrets](#setting-translation-secrets)
+            - [Using with Nvidia GPU](#using-with-nvidia-gpu)
+            - [Building locally](#building-locally)
+    - [Usage](#usage)
+        - [Batch mode (default)](#batch-mode-default)
+        - [Demo mode](#demo-mode)
+        - [Web Mode](#web-mode)
+        - [Api Mode](#api-mode)
+    - [Related Projects](#related-projects)
+    - [Docs](#docs)
+        - [Recommended Modules](#recommended-modules)
+            - [Tips to improve translation quality](#tips-to-improve-translation-quality)
+        - [Options](#options)
+        - [Language Code Reference](#language-code-reference)
+        - [Translators Reference](#translators-reference)
+        - [Config Documentation](#config-file)
+        - [GPT Config Reference](#gpt-config-reference)
+        - [Using Gimp for rendering](#using-gimp-for-rendering)
+        - [Api Documentation](#api-documentation)
+            - [Synchronous mode](#synchronous-mode)
+            - [Asynchronous mode](#asynchronous-mode)
+            - [Manual translation](#manual-translation)
+    - [Next steps](#next-steps)
+    - [Support Us](#support-us)
+        - [Thanks To All Our Contributors :](#thanks-to-all-our-contributors-)
 
 ## Samples
 
@@ -141,11 +141,13 @@ Browser Userscript (by QiroNT): <https://greasyfork.org/scripts/437569>
 - Note this online demo is using the current main branch version.
 
 ## Disclaimer
+
 Successor to [MMDOCR-HighPerformance](https://github.com/PatchyVideo/MMDOCR-HighPerformance).\
 **This is a hobby project, you are welcome to contribute!**\
 Currently this only a simple demo, many imperfections exist, we need your support to make this project better!\
 Primarily designed for translating Japanese text, but also supports Chinese, English and Korean.\
 Supports inpainting, text rendering and colorization.
+
 ## Installation
 
 ### Local setup
@@ -288,26 +290,30 @@ $ cd server && python main.py --use-gpu
 ```
 
 ## Related Projects
+
 GUI implementation: [BallonsTranslator](https://github.com/dmMaze/BallonsTranslator)
 
 ## Docs
 
 ### Recommended Modules
+
 Detector:
+
 - ENG: ??
 - JPN: ??
 - CHS: ??
 - KOR: ??
 - Using `{"detector":{"detector": "ctd"}}` can increase the amount of text lines detected
 
-
 OCR:
+
 - ENG: ??
 - JPN: ??
 - CHS: ??
 - KOR: 48px
 
 Translator:
+
 - JPN -> ENG: **Sugoi**
 - CHS -> ENG: ??
 - CHS -> JPN: ??
@@ -385,25 +391,25 @@ FIL: Filipino (Tagalog)
 
 ### Translators Reference
 
-| Name       | API Key | Offline | Note                                                   |
-|------------|---------|---------|--------------------------------------------------------|
-| <s>google</s>     |         |         |         Disabled temporarily                                               |
-| youdao     | ✔️      |         | Requires `YOUDAO_APP_KEY` and `YOUDAO_SECRET_KEY`      |
-| baidu      | ✔️      |         | Requires `BAIDU_APP_ID` and `BAIDU_SECRET_KEY`         |
-| deepl      | ✔️      |         | Requires `DEEPL_AUTH_KEY`                              |
-| caiyun     | ✔️      |         | Requires `CAIYUN_TOKEN`                                |
-| gpt3       | ✔️      |         | Implements text-davinci-003. Requires `OPENAI_API_KEY` |
-| gpt3.5     | ✔️      |         | Implements gpt-3.5-turbo. Requires `OPENAI_API_KEY`    |
-| gpt4       | ✔️      |         | Implements gpt-4. Requires `OPENAI_API_KEY`            |
-| papago     |         |         |                                                        |
-| sakura     |         |         |Requires `SAKURA_API_BASE`                               |
-| ollama     |         |         |Requires  `OLLAMA_API_BASE` `OLLAMA_MODEL`               |
-| offline    |         | ✔️      | Chooses most suitable offline translator for language  |
-| sugoi      |         | ✔️      | Sugoi V4.0 Models                                      |
-| m2m100     |         | ✔️      | Supports every language                                |
-| m2m100_big |         | ✔️      |                                                        |
-| none       |         | ✔️      | Translate to empty texts                               |
-| original   |         | ✔️      | Keep original texts                                    |
+| Name          | API Key | Offline | Note                                                     |
+|---------------|---------|---------|----------------------------------------------------------|
+| <s>google</s> |         |         | Disabled temporarily                                     |
+| youdao        | ✔️      |         | Requires `YOUDAO_APP_KEY` and `YOUDAO_SECRET_KEY`        |
+| baidu         | ✔️      |         | Requires `BAIDU_APP_ID` and `BAIDU_SECRET_KEY`           |
+| deepl         | ✔️      |         | Requires `DEEPL_AUTH_KEY`                                |
+| caiyun        | ✔️      |         | Requires `CAIYUN_TOKEN`                                  |
+| gpt3          | ✔️      |         | Implements text-davinci-003. Requires `OPENAI_API_KEY`   |
+| gpt3.5        | ✔️      |         | Implements gpt-3.5-turbo. Requires `OPENAI_API_KEY`      |
+| gpt4          | ✔️      |         | Implements gpt-4. Requires `OPENAI_API_KEY`              |
+| papago        |         |         |                                                          |
+| sakura        |         |         | Requires `SAKURA_API_BASE`                               |
+| custom openai |         |         | Requires  `CUSTOM_OPENAI_API_BASE` `CUSTOM_OPENAI_MODEL` |
+| offline       |         | ✔️      | Chooses most suitable offline translator for language    |
+| sugoi         |         | ✔️      | Sugoi V4.0 Models                                        |
+| m2m100        |         | ✔️      | Supports every language                                  |
+| m2m100_big    |         | ✔️      |                                                          |
+| none          |         | ✔️      | Translate to empty texts                                 |
+| original      |         | ✔️      | Keep original texts                                      |
 
 - API Key: Whether the translator requires an API key to be set as environment variable.
   For this you can create a .env file in the project root directory containing your api keys like so:
@@ -416,10 +422,13 @@ DEEPL_AUTH_KEY=xxxxxxxx...
 - Offline: Whether the translator can be used offline.
 
 - Sugoi is created by mingshiba, please support him in https://www.patreon.com/mingshiba
+
 ### Config file
-run `python -m manga_translator config-help >> config-info.json` 
+
+run `python -m manga_translator config-help >> config-info.json`
 
 an example can be found in example/config-example.json
+
 ```json
 {
   "$defs": {
@@ -945,6 +954,7 @@ an example can be found in example/config-example.json
 }
 
 ```
+
 ### GPT Config Reference
 
 Used by the `--gpt-config` argument.

--- a/manga_translator/config.py
+++ b/manga_translator/config.py
@@ -118,7 +118,7 @@ class Translator(str, Enum):
     sakura = "sakura"
     deepseek = "deepseek"
     groq = "groq"
-    ollama = "ollama"
+    custom_openai = "custom_openai"
     offline = "offline"
     nllb = "nllb"
     nllb_big = "nllb_big"

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -21,7 +21,7 @@ from .original import OriginalTranslator
 from .sakura import SakuraTranslator
 from .qwen2 import Qwen2Translator, Qwen2BigTranslator
 from .groq import GroqTranslator
-from .ollama import OllamaTranslator
+from .custom_openai import CustomOpenAiTranslator
 from ..config import Translator, TranslatorConfig, TranslatorChain
 from ..utils import Context
 
@@ -52,7 +52,7 @@ TRANSLATORS = {
     Translator.sakura: SakuraTranslator,
     Translator.deepseek: DeepseekTranslator,
     Translator.groq:GroqTranslator,
-    Translator.ollama: OllamaTranslator,
+    Translator.custom_openai: CustomOpenAiTranslator,
     **OFFLINE_TRANSLATORS,
 }
 translator_cache = {}

--- a/manga_translator/translators/custom_openai.py
+++ b/manga_translator/translators/custom_openai.py
@@ -32,19 +32,19 @@ class CustomOpenAiTranslator(ConfigGPT, CommonTranslator):
 
     # 是否包含模板，用于决定是否使用预设的提示模板
     _INCLUDE_TEMPLATE = False
-    
-    def __init__(self, check_openai_key=False):
+
+    def __init__(self, model=None, api_base=None, api_key=None, check_openai_key=False):
         # If the user has specified a nested key to use for the model, append the key
         #   Otherwise: Use the `ollama` defaults.
         _CONFIG_KEY='ollama'
         if CUSTOM_OPENAI_MODEL_CONF:
             _CONFIG_KEY+=f".{CUSTOM_OPENAI_MODEL_CONF}"
-        
-        ConfigGPT.__init__(self, config_key=_CONFIG_KEY) 
-        CommonTranslator.__init__(self)
 
-        self.client = openai.AsyncOpenAI(api_key=CUSTOM_OPENAI_API_KEY or "ollama") # required, but unused for ollama
-        self.client.base_url = CUSTOM_OPENAI_API_BASE
+        ConfigGPT.__init__(self, config_key=_CONFIG_KEY)
+        self.model = model
+        CommonTranslator.__init__(self)
+        self.client = openai.AsyncOpenAI(api_key=api_key or CUSTOM_OPENAI_API_KEY or "ollama") # required, but unused for ollama
+        self.client.base_url = api_base or CUSTOM_OPENAI_API_BASE
         self.token_count = 0
         self.token_count_last = 0
 
@@ -219,7 +219,7 @@ class CustomOpenAiTranslator(ConfigGPT, CommonTranslator):
         messages.append({'role': 'user', 'content': prompt})
 
         response = await self.client.chat.completions.create(
-            model=CUSTOM_OPENAI_MODEL,
+            model=self.model or CUSTOM_OPENAI_MODEL,
             messages=messages,
             max_tokens=self._MAX_TOKENS // 2,
             temperature=self.temperature,

--- a/manga_translator/translators/custom_openai.py
+++ b/manga_translator/translators/custom_openai.py
@@ -9,13 +9,12 @@ except ImportError:
     openai = None
 import asyncio
 import time
-from typing import List, Dict
-from omegaconf import OmegaConf
-from .common import CommonTranslator, MissingAPIKeyException, VALID_LANGUAGES
-from .keys import OLLAMA_API_KEY, OLLAMA_API_BASE, OLLAMA_MODEL, OLLAMA_MODEL_CONF
+from typing import List
+from .common import CommonTranslator, VALID_LANGUAGES
+from .keys import CUSTOM_OPENAI_API_KEY, CUSTOM_OPENAI_API_BASE, CUSTOM_OPENAI_MODEL, CUSTOM_OPENAI_MODEL_CONF
 
 
-class OllamaTranslator(ConfigGPT, CommonTranslator):
+class CustomOpenAiTranslator(ConfigGPT, CommonTranslator):
     _LANGUAGE_CODE_MAP=VALID_LANGUAGES
 
     _INVALID_REPEAT_COUNT = 2  # 如果检测到“无效”翻译，最多重复 2 次
@@ -38,14 +37,14 @@ class OllamaTranslator(ConfigGPT, CommonTranslator):
         # If the user has specified a nested key to use for the model, append the key
         #   Otherwise: Use the `ollama` defaults.
         _CONFIG_KEY='ollama'
-        if OLLAMA_MODEL_CONF:
-            _CONFIG_KEY+=f".{OLLAMA_MODEL_CONF}" 
+        if CUSTOM_OPENAI_MODEL_CONF:
+            _CONFIG_KEY+=f".{CUSTOM_OPENAI_MODEL_CONF}"
         
         ConfigGPT.__init__(self, config_key=_CONFIG_KEY) 
         CommonTranslator.__init__(self)
 
-        self.client = openai.AsyncOpenAI(api_key=OLLAMA_API_KEY or "ollama") # required, but unused for ollama
-        self.client.base_url = OLLAMA_API_BASE
+        self.client = openai.AsyncOpenAI(api_key=CUSTOM_OPENAI_API_KEY or "ollama") # required, but unused for ollama
+        self.client.base_url = CUSTOM_OPENAI_API_BASE
         self.token_count = 0
         self.token_count_last = 0
 
@@ -220,7 +219,7 @@ class OllamaTranslator(ConfigGPT, CommonTranslator):
         messages.append({'role': 'user', 'content': prompt})
 
         response = await self.client.chat.completions.create(
-            model=OLLAMA_MODEL,
+            model=CUSTOM_OPENAI_MODEL,
             messages=messages,
             max_tokens=self._MAX_TOKENS // 2,
             temperature=self.temperature,

--- a/manga_translator/translators/keys.py
+++ b/manga_translator/translators/keys.py
@@ -32,7 +32,7 @@ DEEPSEEK_API_KEY = os.getenv('DEEPSEEK_API_KEY', '')
 DEEPSEEK_API_BASE  = os.getenv('DEEPSEEK_API_BASE', 'https://api.deepseek.com')
 
 # ollama, with OpenAI API compatibility
-OLLAMA_API_KEY = os.getenv('OLLAMA_API_KEY', 'ollama') # Unsed for ollama, but maybe useful for other LLM tools.
-OLLAMA_API_BASE = os.getenv('OLLAMA_API_BASE', 'http://localhost:11434/v1') # Use OLLAMA_HOST env to change binding IP and Port.
-OLLAMA_MODEL = os.getenv('OLLAMA_MODEL', '') # e.g "qwen2.5:7b". Make sure to pull and run it before use.
-OLLAMA_MODEL_CONF = os.getenv('OLLAMA_MODEL_CONF', '') # e.g "qwen2". 
+CUSTOM_OPENAI_API_KEY = os.getenv('CUSTOM_OPENAI_API_KEY', 'ollama') # Unsed for ollama, but maybe useful for other LLM tools.
+CUSTOM_OPENAI_API_BASE = os.getenv('CUSTOM_OPENAI_API_BASE', 'http://localhost:11434/v1') # Use OLLAMA_HOST env to change binding IP and Port.
+CUSTOM_OPENAI_MODEL = os.getenv('CUSTOM_OPENAI_MODEL', '') # e.g "qwen2.5:7b". Make sure to pull and run it before use.
+CUSTOM_OPENAI_MODEL_CONF = os.getenv('CUSTOM_OPENAI_MODEL_CONF', '') # e.g "qwen2".


### PR DESCRIPTION
i am planing to add this https://github.com/zyddnys/manga-image-translator/issues/849 and noticed that there was already a module named ollama but not using ollama but openai so i renamed i 