### PR TITLE
Fix Dockerfile and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ ENV PYTHONPATH="/app"
 
 WORKDIR /app
 
-ENTRYPOINT ["python"]
+ENTRYPOINT ["python", "-m", "manga_translator"]

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ build-image:
 	docker build . --tag=manga-image-translator
 
 run-web-server:
-	docker run --gpus all -p 5003:5003 --ipc=host --rm zyddnys/manga-image-translator:main \
+	docker run --gpus all -p 5003:5003 --ipc=host --rm manga-image-translator \
 		--target-lang=ENG \
 		--manga2eng \
 		--verbose \
 		--mode=web \
-		--use-gpu \ 
+		--use-gpu \
 		--host=0.0.0.0 \
 		--port=5003


### PR DESCRIPTION
In order for `make build-image && make run-web-server` to work I had to modify:

### Dockerfile

The Docker's ENTRYPOINT is set to ["python"] but it's trying to run the Python module with all the command line arguments. When you run the container, it just tries to execute Python with those arguments rather than running your manga translator module.

### Makefile

Locally I want to use the local image name if I use `zyddnys/manga-image-translator` this will pull the one remotely.
