### PR TITLE
fix prep_manual

### DIFF
--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -715,6 +715,13 @@ class MangaTranslator:
     async def _run_text_rendering(self, config: Config, ctx: Context):
         current_time = time.time()
         self._model_usage_timestamps[("rendering", config.render.renderer)] = current_time
+        
+        inpainter_type = config.inpainter.inpainter  # Defaults to the inpainter specified in the configuration file.
+        if ctx.prep_manual:
+            inpainter_type = Inpainter.none  # If prep_manual is True, forces the use of the 'none' inpainter.
+        return await dispatch_inpainting(inpainter_type, ctx.img_rgb, ctx.mask, config.inpainter, config.inpainter.inpainting_size, self.device,
+                                         self.verbose)
+        
         if config.render.renderer == Renderer.none:
             output = ctx.img_inpainted
         # manga2eng currently only supports horizontal left to right rendering


### PR DESCRIPTION
`--prep-manual` 失灵了，旧版的这个参数可以在源文件夹输出txt文件，可以在`example-translated`文件夹中输出`example-orig.png`文件和对应去除文字的`exampel.png`文件，但在新版中源文件夹中没有输出txt文件，在`example-translated`文件夹中输出的`exampel.png`文件也是含文字的译后文件。

修正后仅会在目标文件夹中输出去除文字的图片，不含源文件