### PR TITLE
fix direction param

### DIFF
--- a/manga_translator/rendering/__init__.py
+++ b/manga_translator/rendering/__init__.py
@@ -137,14 +137,28 @@ def render(
     norm_v = np.linalg.norm(middle_pts[:, 2] - middle_pts[:, 0], axis=1)
     r_orig = np.mean(norm_h / norm_v)
 
-    if region.horizontal:
+    # 如果配置中设定了非自动模式，则直接使用配置决定方向
+    forced_direction = region._direction if hasattr(region, "_direction") else region.direction
+    if forced_direction != "auto":
+        if forced_direction in ["horizontal", "h"]:
+            render_horizontally = True
+        elif forced_direction in ["vertical", "v"]:
+            render_horizontally = False
+        else:
+            render_horizontally = region.horizontal
+    else:
+        render_horizontally = region.horizontal
+
+    print(f"Region text: {region.text}, forced_direction: {forced_direction}, render_horizontally: {render_horizontally}")
+
+    if render_horizontally:
         temp_box = text_render.put_text_horizontal(
             region.font_size,
             region.get_translation_for_rendering(),
             round(norm_h[0]),
             round(norm_v[0]),
             region.alignment,
-            region.direction == 'hr',
+            True,  # 强制水平排版
             fg,
             bg,
             region.target_lang,

--- a/manga_translator/rendering/__init__.py
+++ b/manga_translator/rendering/__init__.py
@@ -158,7 +158,7 @@ def render(
             round(norm_h[0]),
             round(norm_v[0]),
             region.alignment,
-            True,  # 强制水平排版
+            region.direction == 'hl',
             fg,
             bg,
             region.target_lang,


### PR DESCRIPTION
文本区域（TextBlock）的水平/竖直属性（即 region.horizontal 和 region.vertical）是在文本检测和合并时根据原始角度自动计算的，而配置文件中设置的 direction（例如“horizontal”）没有覆盖这一计算结果。也就是说，即使在 config 中将 direction 设为 horizontal 或 vertical，但翻译后生成的 TextBlock 仍然保留了原来的方向信息，导致排版参数失灵。这应该是修复的第五个失灵的参数，现在`--verbose`好像也失灵了，加不加没区别

The horizontal/vertical properties (i.e., region.horizontal and region.vertical) of a TextBlock are automatically calculated based on the original angle during text detection and merging. The direction set in the configuration file (e.g., "horizontal") does not override this calculation. In other words, even if the direction is set to horizontal or vertical in the config, the generated TextBlock after translation still retains the original direction information, causing the typesetting parameters to fail. So many parameters are malfunctioning... Now the `--verbose` parameter is also problematic; adding it or not makes no difference.