### PR TITLE
check prefix, improve char rendering, discard https change

### DIFF
--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -496,7 +496,7 @@ class MangaTranslator:
             # Modified filtering condition: handle incomplete parentheses  
             bracket_pairs = {  
                 '(': ')', '（': '）', '[': ']', '【': '】', '{': '}', '〔': '〕', '〈': '〉', '「': '」',  
-                '"': '"', "'": "'", '《': '》', '『': '』', '"': '"', '〝': '〞', '﹁': '﹂', '﹃': '﹄',  
+                '"': '"', '＂': '＂', "'": "'", "“": "”", '《': '》', '『': '』', '"': '"', '〝': '〞', '﹁': '﹂', '﹃': '﹄',  
                 '⸂': '⸃', '⸄': '⸅', '⸉': '⸊', '⸌': '⸍', '⸜': '⸝', '⸠': '⸡', '‹': '›', '«': '»', '＜': '＞', '<': '>'  
             }  
             left_symbols = set(bracket_pairs.keys())  
@@ -711,9 +711,10 @@ class MangaTranslator:
                 if quote_type:
                     src_quote_count = region.text.count(quote_type[0])
                     dst_dquote_count = region.translation.count('"')
+                    dst_fwquote_count = region.translation.count('＂')
                     
                     if (src_quote_count > 0 and
-                        src_quote_count == dst_dquote_count and
+                        (src_quote_count == dst_dquote_count or src_quote_count == dst_fwquote_count) and
                         not region.translation.isascii()):
                         
                         if quote_type == '「」':

--- a/manga_translator/rendering/__init__.py
+++ b/manga_translator/rendering/__init__.py
@@ -149,7 +149,7 @@ def render(
     else:
         render_horizontally = region.horizontal
 
-    print(f"Region text: {region.text}, forced_direction: {forced_direction}, render_horizontally: {render_horizontally}")
+    #print(f"Region text: {region.text}, forced_direction: {forced_direction}, render_horizontally: {render_horizontally}")
 
     if render_horizontally:
         temp_box = text_render.put_text_horizontal(

--- a/manga_translator/rendering/text_render.py
+++ b/manga_translator/rendering/text_render.py
@@ -82,10 +82,9 @@ def CJK_Compatibility_Forms_translate(cdpt: str, direction: int):
 def compact_special_symbols(text: str) -> str:  
     text = text.replace('...', '…')  
     text = text.replace('..', '…')      
-    # Remove half-width and full-width spaces between punctuation marks  
-    pattern = r'([^\w\s])[ \u3000]+([^\w\s])'  
-    while re.search(pattern, text):  
-        text = re.sub(pattern, r'\1\2', text)  
+    # Remove half-width and full-width spaces after each punctuation mark
+    pattern = r'([^\w\s])[ \u3000]+'  
+    text = re.sub(pattern, r'\1', text) 
 
 def rotate_image(image, angle):
     if angle == 0:

--- a/manga_translator/rendering/text_render.py
+++ b/manga_translator/rendering/text_render.py
@@ -79,9 +79,13 @@ def CJK_Compatibility_Forms_translate(cdpt: str, direction: int):
             return cdpt, 0
     return cdpt, 0
 
-def compact_special_symbols(text: str) -> str :
-    text = text.replace('...', '…')
-    return text
+def compact_special_symbols(text: str) -> str:  
+    text = text.replace('...', '…')  
+    text = text.replace('..', '…')      
+    # Remove half-width and full-width spaces between punctuation marks  
+    pattern = r'([^\w\s])[ \u3000]+([^\w\s])'  
+    while re.search(pattern, text):  
+        text = re.sub(pattern, r'\1\2', text)  
 
 def rotate_image(image, angle):
     if angle == 0:

--- a/manga_translator/rendering/text_render.py
+++ b/manga_translator/rendering/text_render.py
@@ -282,35 +282,195 @@ def calc_vertical(font_size: int, text: str, max_height: int):
     # box_calc_y = max(line_height_list)
     return line_text_list, line_height_list
 
-def put_char_vertical(font_size: int, cdpt: str, pen_l: Tuple[int, int], canvas_text: np.ndarray, canvas_border: np.ndarray, border_size: int):
-    pen = pen_l.copy()
+def put_char_vertical(font_size: int, cdpt: str, pen_l: Tuple[int, int], canvas_text: np.ndarray, canvas_border: np.ndarray, border_size: int):  
+    """  
+    在画布上垂直放置一个字符，并可选地添加描边效果。  
+    Vertically place a character on the canvas with optional border effect.  
+    
+    Args:  
+        font_size: 字体大小 / Font size  
+        cdpt: 要渲染的字符 / Character to render  
+        pen_l: 笔的位置（起始绘制位置） / Pen position (starting drawing position)  
+        canvas_text: 用于绘制文本的NumPy数组 / NumPy array for drawing text  
+        canvas_border: 用于绘制描边的NumPy数组 / NumPy array for drawing border  
+        border_size: 描边大小 / Border size  
+        
+    Returns:  
+        int: 垂直步进值 / Vertical advance value  
+    """  
+    # 复制笔位置，避免修改原始值  
+    # Copy pen position to avoid modifying the original value  
+    pen = pen_l.copy()  
 
-    is_pun = is_punctuation(cdpt)
-    cdpt, rot_degree = CJK_Compatibility_Forms_translate(cdpt, 1)
-    slot = get_char_glyph(cdpt, font_size, 1)
-    bitmap = slot.bitmap
-    if bitmap.rows * bitmap.width == 0 or len(bitmap.buffer) != bitmap.rows * bitmap.width:
-        char_offset_y = slot.metrics.vertBearingY >> 6
-        return char_offset_y
-    char_offset_y = slot.metrics.vertAdvance >> 6
-    bitmap_char = np.array(bitmap.buffer, dtype = np.uint8).reshape((bitmap.rows,bitmap.width))
-    pen[0] += slot.metrics.vertBearingX >> 6
-    pen[1] += slot.metrics.vertBearingY >> 6
-    canvas_text[pen[1]:pen[1]+bitmap.rows, pen[0]:pen[0]+bitmap.width] = bitmap_char
-    #print(pen_l, pen, slot.metrics.vertBearingX >> 6, bitmap.width)
-    #border
-    if border_size > 0:
-        pen_border = (max(pen[0] - border_size, 0), max(pen[1] - border_size, 0))
-        #slot_border = 
-        glyph_border = get_char_border(cdpt, font_size, 1)
-        stroker = freetype.Stroker()
-        stroker.set(64 * max(int(0.07 * font_size), 1), freetype.FT_STROKER_LINEJOIN_ROUND, freetype.FT_STROKER_LINEJOIN_ROUND, 0)
-        glyph_border.stroke(stroker, destroy=True)
-        blyph = glyph_border.to_bitmap(freetype.FT_RENDER_MODE_NORMAL, freetype.Vector(0,0), True)
-        bitmap_b = blyph.bitmap
-        bitmap_border = np.array(bitmap_b.buffer, dtype = np.uint8).reshape(bitmap_b.rows, bitmap_b.width)
-        canvas_border[pen_border[1]:pen_border[1]+bitmap_b.rows, pen_border[0]:pen_border[0]+bitmap_b.width] = cv2.add(canvas_border[pen_border[1]:pen_border[1]+bitmap_b.rows, pen_border[0]:pen_border[0]+bitmap_b.width], bitmap_border)
-    return char_offset_y
+    # 检查是否是标点符号  
+    # Check if the character is a punctuation  
+    is_pun = is_punctuation(cdpt)  
+    
+    # 处理CJK兼容形式转换，并获取旋转角度  
+    # Process CJK compatibility forms translation and get rotation degree  
+    cdpt, rot_degree = CJK_Compatibility_Forms_translate(cdpt, 1)  
+    
+    # 获取字符字形  
+    # Get character glyph  
+    slot = get_char_glyph(cdpt, font_size, 1)  
+    bitmap = slot.bitmap  # 这是原始字符的 bitmap 对象 / This is the bitmap object of the original character  
+
+    # --- 获取原始字符位图信息 / Get original character bitmap information ---  
+    char_bitmap_rows = bitmap.rows  
+    char_bitmap_width = bitmap.width  
+    
+    # 检查位图是否有效（如空格等字符可能没有有效位图）  
+    # Check if the bitmap is valid (characters like spaces may not have valid bitmaps)  
+    if char_bitmap_rows * char_bitmap_width == 0 or len(bitmap.buffer) != char_bitmap_rows * char_bitmap_width:  
+        # 对于无效位图（如空格），计算垂直步进 char_offset_y  
+        # For invalid bitmaps (like spaces), calculate vertical advance char_offset_y  
+
+        # 优先使用 vertAdvance (这是最适合垂直布局的)  
+        # Prefer to use vertAdvance (this is most suitable for vertical layout)  
+        if hasattr(slot, 'metrics') and hasattr(slot.metrics, 'vertAdvance') and slot.metrics.vertAdvance:  
+             char_offset_y = slot.metrics.vertAdvance >> 6  
+        # 其次尝试 advance.y (理论上 vertAdvance 更可靠)  
+        # Then try advance.y (theoretically vertAdvance is more reliable)  
+        elif hasattr(slot, 'advance') and slot.advance.y:  
+             char_offset_y = slot.advance.y >> 6  
+        # 再次尝试 vertBearingY (作为最后的度量回退，虽然不是步进值)  
+        # Then try vertBearingY (as a last metric fallback, although not an advance value)  
+        elif hasattr(slot, 'metrics') and hasattr(slot.metrics, 'vertBearingY'):  
+             char_offset_y = slot.metrics.vertBearingY >> 6  
+        # 最后的手段：使用 font_size 作为估算值  
+        # Last resort: use font_size as an estimated value  
+        else:  
+             char_offset_y = font_size  
+
+        # 对于空白字符等，只返回垂直步进距离  
+        # For whitespace characters, just return the vertical advance  
+        return char_offset_y  
+
+    # --- 对于有效位图，正常处理 / For valid bitmaps, process normally ---  
+    # 这里的 char_offset_y 应该是最终的垂直步进  
+    # Here char_offset_y should be the final vertical advance  
+    char_offset_y = slot.metrics.vertAdvance >> 6  
+
+    # 将位图缓冲区转换为NumPy数组  
+    # Convert bitmap buffer to NumPy array  
+    bitmap_char = np.array(bitmap.buffer, dtype=np.uint8).reshape((char_bitmap_rows, char_bitmap_width))  
+
+    # --- 计算原始字符在画布上的放置位置 (左上角) ---  
+    # --- Calculate the placement position of the original character on canvas (top-left corner) ---  
+    # 注意：这里的 pen[0] 和 pen[1] 是放置 bitmap_char 的左上角参考点  
+    # Note: pen[0] and pen[1] are the top-left reference points for placing bitmap_char  
+    char_place_x = pen[0] + (slot.metrics.vertBearingX >> 6)  
+    char_place_y = pen[1] + (slot.metrics.vertBearingY >> 6)   
+
+    # 在 canvas_text 上放置原始字符  
+    # Place the original character on canvas_text  
+    # 确保索引不为负  
+    # Ensure indices are not negative  
+    paste_y_start = max(0, char_place_y)  
+    paste_x_start = max(0, char_place_x)  
+    paste_y_end = min(canvas_text.shape[0], char_place_y + char_bitmap_rows)  
+    paste_x_end = min(canvas_text.shape[1], char_place_x + char_bitmap_width)  
+    
+    # 确保切片源和目标尺寸匹配  
+    # Ensure slice source and target dimensions match  
+    bitmap_char_slice = bitmap_char[paste_y_start-char_place_y : paste_y_end-char_place_y,   
+                                    paste_x_start-char_place_x : paste_x_end-char_place_x]  
+    if bitmap_char_slice.size > 0:  
+         canvas_text[paste_y_start:paste_y_end, paste_x_start:paste_x_end] = bitmap_char_slice  
+
+    # --- 处理描边 / Process border ---  
+    if border_size > 0:  
+        # 获取字符描边  
+        # Get character border  
+        glyph_border = get_char_border(cdpt, font_size, 1)  
+        stroker = freetype.Stroker()  
+        
+        # 设置描边半径和样式  
+        # Set stroke radius and style  
+        stroke_radius = 64 * max(int(0.07 * font_size), 1)  # 基于字体大小的比例值 / Proportional value based on font size  
+        stroker.set(stroke_radius, freetype.FT_STROKER_LINEJOIN_ROUND, freetype.FT_STROKER_LINECAP_ROUND, 0)  
+        
+        # 应用描边效果  
+        # Apply stroke effect  
+        glyph_border.stroke(stroker, destroy=True)  
+        
+        # 渲染描边字形到位图  
+        # Render stroked glyph to bitmap  
+        blyph = glyph_border.to_bitmap(freetype.FT_RENDER_MODE_NORMAL, freetype.Vector(0, 0), True)  
+        bitmap_b = blyph.bitmap  # 这是描边后的 bitmap 对象 / This is the bitmap object after stroking  
+
+        # --- 获取描边位图信息 / Get border bitmap information ---  
+        border_bitmap_rows = bitmap_b.rows  
+        border_bitmap_width = bitmap_b.width  
+
+        if border_bitmap_rows * border_bitmap_width > 0 and len(bitmap_b.buffer) == border_bitmap_rows * border_bitmap_width:  
+            # 将描边位图缓冲区转换为NumPy数组  
+            # Convert border bitmap buffer to NumPy array  
+            bitmap_border = np.array(bitmap_b.buffer, dtype=np.uint8).reshape((border_bitmap_rows, border_bitmap_width))  
+
+            # --- 计算描边位图放置位置，使其中心与原始字符位图中心对齐 ---  
+            # --- Calculate border bitmap placement position to align its center with the original character bitmap center ---  
+            
+            # 原始字符位图中心偏移 (相对于其左上角)  
+            # Original character bitmap center offset (relative to its top-left corner)  
+            char_center_offset_x = char_bitmap_width / 2.0  
+            char_center_offset_y = char_bitmap_rows / 2.0  
+            
+            # 描边位图中心偏移 (相对于其左上角)  
+            # Border bitmap center offset (relative to its top-left corner)  
+            border_center_offset_x = border_bitmap_width / 2.0  
+            border_center_offset_y = border_bitmap_rows / 2.0  
+
+            # 原始字符中心在画布上的坐标  
+            # Coordinates of the original character center on canvas  
+            char_center_on_canvas_x = char_place_x + char_center_offset_x  
+            char_center_on_canvas_y = char_place_y + char_center_offset_y  
+
+            # 计算描边位图的左上角放置位置 (pen_border)，使得其中心与字符中心重合  
+            # Calculate the top-left placement position of border bitmap (pen_border) so that its center coincides with the character center  
+            pen_border_x_float = char_center_on_canvas_x - border_center_offset_x  
+            pen_border_y_float = char_center_on_canvas_y - border_center_offset_y  
+
+            # 转换为整数坐标  
+            # Convert to integer coordinates  
+            pen_border_x = int(round(pen_border_x_float))  
+            pen_border_y = int(round(pen_border_y_float))  
+
+            # 最终的 pen_border，确保不小于 0  
+            # Final pen_border, ensure not less than 0  
+            pen_border = (max(0, pen_border_x), max(0, pen_border_y))  
+
+            # --- 在 canvas_border 上放置描边位图 / Place border bitmap on canvas_border ---  
+            # 确保索引不为负，且在画布范围内  
+            # Ensure indices are not negative and within canvas range  
+            paste_border_y_start = pen_border[1]  
+            paste_border_x_start = pen_border[0]  
+            paste_border_y_end = min(canvas_border.shape[0], pen_border[1] + border_bitmap_rows)  
+            paste_border_x_end = min(canvas_border.shape[1], pen_border[0] + border_bitmap_width)  
+
+            # 确保切片源和目标尺寸匹配  
+            # Ensure slice source and target dimensions match  
+            bitmap_border_slice = bitmap_border[0 : paste_border_y_end-paste_border_y_start,   
+                                               0 : paste_border_x_end-paste_border_x_start]  
+
+            if bitmap_border_slice.size > 0:  
+                # 使用 cv2.add 叠加描边  
+                # Use cv2.add to overlay border  
+                target_slice = canvas_border[paste_border_y_start:paste_border_y_end,   
+                                           paste_border_x_start:paste_border_x_end]  
+                # 确保形状匹配后再添加  
+                # Ensure shapes match before adding  
+                if target_slice.shape == bitmap_border_slice.shape:  
+                    canvas_border[paste_border_y_start:paste_border_y_end,   
+                                paste_border_x_start:paste_border_x_end] = cv2.add(target_slice, bitmap_border_slice)  
+                else:  
+                    # 处理形状不匹配的情况  
+                    # Handle shape mismatch if necessary  
+                    print(f"Shape mismatch: target={target_slice.shape}, source={bitmap_border_slice.shape}")  
+
+    # 返回垂直步进值  
+    # Return vertical advance value  
+    return char_offset_y  
 
 def put_text_vertical(font_size: int, text: str, h: int, alignment: str, fg: Tuple[int, int, int], bg: Optional[Tuple[int, int, int]], line_spacing: int):
     text = compact_special_symbols(text)
@@ -653,33 +813,223 @@ def calc_horizontal(font_size: int, text: str, max_width: int, max_height: int, 
 
 
 def put_char_horizontal(font_size: int, cdpt: str, pen_l: Tuple[int, int], canvas_text: np.ndarray, canvas_border: np.ndarray, border_size: int):
-    pen = pen_l.copy()
+    """
+    Render a single character (with optional stroke) onto horizontally oriented canvas.
+    将单个字符（包括可能的描边）渲染到水平方向的画布上。
 
+    Args:
+        font_size: Font size in pixels. 字体大小（像素）
+        cdpt: Character to render. 要渲染的字符
+        pen_l: Current pen position (x, y), where x is horizontal origin and y is baseline. 
+               画笔的当前位置 (x, y)，其中 x 是水平原点，y 是基线
+        canvas_text: Grayscale canvas for character rendering (numpy array).
+                    用于渲染字符本身的灰度画布 (numpy array)
+        canvas_border: Grayscale canvas for stroke rendering (numpy array).
+                      用于渲染字符描边的灰度画布 (numpy array)
+        border_size: Target stroke size (used to calculate stroker radius, enabled when >0).
+                    描边的目标大小（用于计算描边器半径，>0 时启用描边）
+
+    Returns:
+        The character's horizontal advance distance (int). 该字符的水平步进距离 (int)
+    """
+    pen = list(pen_l)  # Use mutable copy 使用可变副本
+
+    # Get character and rotation angle (0° means horizontal)
+    # 获取字符和旋转角度（方向0代表水平）
     cdpt, rot_degree = CJK_Compatibility_Forms_translate(cdpt, 0)
+    
+    # Get glyph information 获取字形信息
     slot = get_char_glyph(cdpt, font_size, 0)
-    bitmap = slot.bitmap
-    char_offset_x = slot.advance.x >> 6
-    bitmap_char = np.array(bitmap.buffer, dtype = np.uint8).reshape((bitmap.rows,bitmap.width))
-    if bitmap.rows * bitmap.width == 0 or len(bitmap.buffer) != bitmap.rows * bitmap.width:
-        return char_offset_x
-    pen[0] += slot.bitmap_left
-    pen[1] = max(pen[1] - slot.bitmap_top, 0)
-    canvas_text[pen[1]:pen[1]+bitmap.rows, pen[0]:pen[0]+bitmap.width] = bitmap_char
-    #print(pen_l, pen, slot.metrics.vertBearingX >> 6, bitmap.width)
-    #border
-    if border_size > 0:
-        pen_border = (max(pen[0] - border_size, 0), max(pen[1] - border_size, 0))
-        #slot_border = 
-        glyph_border = get_char_border(cdpt, font_size, 1)
-        stroker = freetype.Stroker()
-        stroker.set(64 * max(int(0.07 * font_size), 1), freetype.FT_STROKER_LINEJOIN_ROUND, freetype.FT_STROKER_LINEJOIN_ROUND, 0)
-        glyph_border.stroke(stroker, destroy=True)
-        blyph = glyph_border.to_bitmap(freetype.FT_RENDER_MODE_NORMAL, freetype.Vector(0,0), True)
-        bitmap_b = blyph.bitmap
-        bitmap_border = np.array(bitmap_b.buffer, dtype = np.uint8).reshape(bitmap_b.rows,bitmap_b.width)
+    bitmap = slot.bitmap  # Original character bitmap 原始字符位图对象
 
-        canvas_border[pen_border[1]:pen_border[1]+bitmap_b.rows, pen_border[0]:pen_border[0]+bitmap_b.width] = cv2.add(canvas_border[pen_border[1]:pen_border[1]+bitmap_b.rows, pen_border[0]:pen_border[0]+bitmap_b.width], bitmap_border)
-    return char_offset_x
+    # --- Calculate horizontal advance (char_offset_x) ---
+    # 优先使用 horiAdvance 获取水平布局的步进
+    # Priority: Use horiAdvance for horizontal layout advance
+    if hasattr(slot, 'metrics') and hasattr(slot.metrics, 'horiAdvance') and slot.metrics.horiAdvance:
+        char_offset_x = slot.metrics.horiAdvance >> 6
+    
+    # Fallback: Use advance.x (usually same as horiAdvance)
+    # 备选：使用 advance.x (通常与 horiAdvance 相同)
+    elif hasattr(slot, 'advance') and slot.advance.x:
+        char_offset_x = slot.advance.x >> 6
+    
+    # Further fallback: Estimate based on bitmap width if metrics missing (rare case)
+    # 更进一步的备选：如果缺少度量信息，基于位图宽度和左跨距估算
+    elif bitmap.width > 0 and hasattr(slot, 'bitmap_left'):
+         char_offset_x = slot.bitmap_left + bitmap.width  # Rough estimation 非常粗略的估算
+    
+    # Final fallback: Guess based on font size
+    # 最后备选：基于字体大小猜测
+    else:
+         char_offset_x = font_size // 2  # If no information available 如果完全没有信息
+
+    # --- Check bitmap validity ---
+    # 处理空格、无效字符等情况，在访问 buffer 前检查
+    # Handle spaces/invalid chars before accessing buffer
+    if bitmap.rows * bitmap.width == 0 or len(bitmap.buffer) != bitmap.rows * bitmap.width:
+        return char_offset_x  # Return advance for empty/invalid bitmap 对于无效或空位图直接返回步进
+
+    # --- For valid bitmap, proceed with rendering ---
+    # 将位图缓冲区转换为 numpy 数组
+    # Convert bitmap buffer to numpy array
+    bitmap_char = np.array(bitmap.buffer, dtype=np.uint8).reshape((bitmap.rows, bitmap.width))
+
+    # --- Calculate character placement ---
+    # pen[0] is horizontal origin (cursor x)
+    # pen[1] is vertical baseline (cursor y)
+    # bitmap_left is horizontal distance from origin to left edge
+    # bitmap_top is vertical distance from baseline to top edge (positive upwards)
+    # pen[0] 是水平原点 (光标的 x 位置)
+    # pen[1] 是垂直基线 (光标的 y 位置)
+    # bitmap_left 是从原点到字形位图左边缘的水平距离
+    # bitmap_top 是从基线到字形位图上边缘的垂直距离 (向上为正)
+    char_place_x = pen[0] + slot.bitmap_left
+    char_place_y = pen[1] - slot.bitmap_top
+
+    # --- Paste character to canvas_text ---
+    # Ensure paste area is within canvas and indices non-negative
+    # 确保粘贴范围在画布内且索引非负
+    paste_y_start = max(0, char_place_y)
+    paste_x_start = max(0, char_place_x)
+    paste_y_end = min(canvas_text.shape[0], char_place_y + bitmap.rows)
+    paste_x_end = min(canvas_text.shape[1], char_place_x + bitmap.width)
+
+    # Calculate source bitmap slicing area
+    # 计算源位图需要切片的区域
+    bitmap_slice_y_start = paste_y_start - char_place_y
+    bitmap_slice_x_start = paste_x_start - char_place_x
+    bitmap_slice_y_end = bitmap_slice_y_start + (paste_y_end - paste_y_start)
+    bitmap_slice_x_end = bitmap_slice_x_start + (paste_x_end - paste_x_start)
+
+    # Extract slice from source bitmap
+    # 从源位图中提取切片
+    bitmap_char_slice = bitmap_char[bitmap_slice_y_start:bitmap_slice_y_end, 
+                                   bitmap_slice_x_start:bitmap_slice_x_end]
+
+    # Paste if slice is valid and shapes match
+    # 检查切片是否有效且形状匹配，然后粘贴
+    if (bitmap_char_slice.size > 0 and 
+        bitmap_char_slice.shape == (paste_y_end - paste_y_start, 
+                                   paste_x_end - paste_x_start)):
+        canvas_text[paste_y_start:paste_y_end, 
+                    paste_x_start:paste_x_end] = bitmap_char_slice
+
+    # --- Handle stroke rendering (if border_size > 0) ---
+    # 处理描边渲染 (如果 border_size > 0)
+    if border_size > 0:
+        # Get glyph outline for stroke 获取用于描边的字形轮廓
+        glyph_border = get_char_border(cdpt, font_size, 0)  # Same horizontal orientation 同样水平方向
+        
+        # Configure stroker 配置描边器
+        stroker = freetype.Stroker()
+        stroke_radius = 64 * max(int(0.07 * font_size), 1)  # In 1/64 pixel units 单位: 1/64 像素
+        stroker.set(stroke_radius, 
+                   freetype.FT_STROKER_LINEJOIN_ROUND,  # Round joins 圆角连接
+                   freetype.FT_STROKER_LINECAP_ROUND,   # Round line caps 圆头线帽
+                   0)
+        
+        # Apply stroke 应用描边
+        glyph_border.stroke(stroker, destroy=True)
+        
+        # Render stroked glyph to bitmap 将描边后的字形渲染到位图
+        blyph = glyph_border.to_bitmap(freetype.FT_RENDER_MODE_NORMAL, 
+                                      freetype.Vector(0, 0), True)
+        bitmap_b = blyph.bitmap  # Stroked bitmap 描边后的位图
+
+        # --- Process stroke bitmap ---
+        border_bitmap_rows = bitmap_b.rows
+        border_bitmap_width = bitmap_b.width
+
+        # Only proceed if stroke bitmap is valid
+        # 仅在描边位图有效时继续
+        if (border_bitmap_rows * border_bitmap_width > 0 and 
+            len(bitmap_b.buffer) == border_bitmap_rows * border_bitmap_width):
+            
+            # Convert stroke bitmap to numpy array
+            # 将描边位图缓冲区转为 numpy 数组
+            bitmap_border = np.array(bitmap_b.buffer, dtype=np.uint8
+                                   ).reshape((border_bitmap_rows, border_bitmap_width))
+
+            # --- Calculate stroke placement (center alignment logic) ---
+            # 原始字符位图的尺寸
+            char_bitmap_rows = bitmap.rows
+            char_bitmap_width = bitmap.width
+
+            # Original character center offsets
+            # 原始字符位图中心相对于其左上角的偏移
+            char_center_offset_x = char_bitmap_width / 2.0
+            char_center_offset_y = char_bitmap_rows / 2.0
+
+            # Stroke bitmap center offsets
+            # 描边位图中心相对于其自身左上角的偏移
+            border_center_offset_x = border_bitmap_width / 2.0
+            border_center_offset_y = border_bitmap_rows / 2.0
+
+            # Calculate absolute center coordinates on canvas
+            # 计算原始字符中心在画布上的绝对坐标
+            char_center_on_canvas_x = char_place_x + char_center_offset_x
+            char_center_on_canvas_y = char_place_y + char_center_offset_y
+
+            # Calculate stroke placement position (pen_border_x/y)
+            # So its center aligns with character center
+            # 计算描边位图的左上角放置位置 (pen_border_x, pen_border_y)
+            # 使得其中心与字符中心对齐
+            pen_border_x_float = char_center_on_canvas_x - border_center_offset_x
+            pen_border_y_float = char_center_on_canvas_y - border_center_offset_y
+
+            # Convert to integer coordinates
+            # 转换为整数坐标进行放置
+            pen_border_x = int(round(pen_border_x_float))
+            pen_border_y = int(round(pen_border_y_float))
+
+            # --- Paste stroke to canvas_border ---
+            # Ensure paste area is within canvas
+            # 确保粘贴范围在画布内且索引非负
+            paste_border_y_start = max(0, pen_border_y)
+            paste_border_x_start = max(0, pen_border_x)
+            paste_border_y_end = min(canvas_border.shape[0], pen_border_y + border_bitmap_rows)
+            paste_border_x_end = min(canvas_border.shape[1], pen_border_x + border_bitmap_width)
+
+            # Calculate source stroke bitmap slicing area
+            # 计算源描边位图需要切片的区域
+            border_slice_y_start = paste_border_y_start - pen_border_y
+            border_slice_x_start = paste_border_x_start - pen_border_x
+            border_slice_y_end = border_slice_y_start + (paste_border_y_end - paste_border_y_start)
+            border_slice_x_end = border_slice_x_start + (paste_border_x_end - paste_border_x_start)
+
+            # Extract slice from stroke bitmap
+            # 从源描边位图中提取切片
+            bitmap_border_slice = bitmap_border[
+                border_slice_y_start:border_slice_y_end,
+                border_slice_x_start:border_slice_x_end
+            ]
+
+            # Check slice validity before pasting
+            # 检查切片是否有效且形状匹配
+            if (bitmap_border_slice.size > 0 and 
+                bitmap_border_slice.shape == (paste_border_y_end - paste_border_y_start,
+                                            paste_border_x_end - paste_border_x_start)):
+                
+                # Get target canvas area
+                # 获取目标画布上的对应区域
+                target_slice = canvas_border[
+                    paste_border_y_start:paste_border_y_end,
+                    paste_border_x_start:paste_border_x_end
+                ]
+                
+                # Ensure shape consistency
+                # 确保形状一致（切片逻辑正确的话应该是一致的）
+                if target_slice.shape == bitmap_border_slice.shape:
+                    # Blend stroke using cv2.add or np.maximum
+                    # 使用 cv2.add 可以平滑合并重叠的描边部分
+                    canvas_border[paste_border_y_start:paste_border_y_end,
+                                paste_border_x_start:paste_border_x_end] = cv2.add(
+                        target_slice, bitmap_border_slice)
+                else:
+                    print(f"[Error] Shape mismatch during border paste: "
+                         f"target={target_slice.shape}, source={bitmap_border_slice.shape}")
+
+    return char_offset_x  # Return horizontal advance 返回水平步进距离
 
 def put_text_horizontal(font_size: int, text: str, width: int, height: int, alignment: str,
                         reversed_direction: bool, fg: Tuple[int, int, int], bg: Tuple[int, int, int],

--- a/manga_translator/rendering/text_render.py
+++ b/manga_translator/rendering/text_render.py
@@ -376,8 +376,13 @@ def put_char_vertical(font_size: int, cdpt: str, pen_l: Tuple[int, int], canvas_
     bitmap_char_slice = bitmap_char[paste_y_start-char_place_y : paste_y_end-char_place_y,   
                                     paste_x_start-char_place_x : paste_x_end-char_place_x]  
     if bitmap_char_slice.size > 0:  
-         canvas_text[paste_y_start:paste_y_end, paste_x_start:paste_x_end] = bitmap_char_slice  
-
+        # 字符完全在画布上方或下方时， paste_y_start 等于 paste_y_end ，切片 paste_y_start:paste_y_end 会产生高度为0的区域
+        # 简单处理，有概率漏字
+        # When a character is completely above or below the canvas, paste_y_start equals paste_y_end, and the slice paste_y_start:paste_y_end will produce a region with height 0.
+        # Simple handling, there's a probability of missing characters
+        if paste_y_start < paste_y_end and paste_x_start < paste_x_end:        
+            canvas_text[paste_y_start:paste_y_end, paste_x_start:paste_x_end] = bitmap_char_slice        
+            
     # --- 处理描边 / Process border ---  
     if border_size > 0:  
         # 获取字符描边  
@@ -453,7 +458,7 @@ def put_char_vertical(font_size: int, cdpt: str, pen_l: Tuple[int, int], canvas_
             bitmap_border_slice = bitmap_border[0 : paste_border_y_end-paste_border_y_start,   
                                                0 : paste_border_x_end-paste_border_x_start]  
 
-            if bitmap_border_slice.size > 0:  
+            if bitmap_border_slice.size > 0 and paste_border_y_end > paste_border_y_start and paste_border_x_end > paste_border_x_start:
                 # 使用 cv2.add 叠加描边  
                 # Use cv2.add to overlay border  
                 target_slice = canvas_border[paste_border_y_start:paste_border_y_end,   

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -375,7 +375,7 @@ class OpenAITranslator(ConfigGPT, CommonTranslator):
                 # Check for special merged translation
                 is_valid_translation = True  
                 for i, (source, translation) in enumerate(zip(batch_queries, new_translations)):  
-                    is_source_simple = len(source) == 1 or all(char in string.punctuation for char in source)  
+                    is_source_simple = all(char in string.punctuation for char in source)  
                     is_translation_simple = len(translation) == 1 or all(char in string.punctuation for char in translation)  
                     
                     if is_translation_simple and not is_source_simple:  

--- a/manga_translator/translators/chatgpt.py
+++ b/manga_translator/translators/chatgpt.py
@@ -313,6 +313,13 @@ class OpenAITranslator(ConfigGPT, CommonTranslator):
                     #await asyncio.sleep(RETRY_BACKOFF_BASE + attempt * RETRY_BACKOFF_FACTOR) # 格式错误重试前等待并退避  
                     continue # 进入下一次重试 / Proceed to next retry  
                 
+                # 跳过经常性的模型幻觉字符
+                # Skip common hallucination characters in specific models
+                SUSPICIOUS_SYMBOLS = ["ହ", "ି", "ഹ"]  
+                if any(symbol in response for symbol in SUSPICIOUS_SYMBOLS):  
+                    self.logger.warn(f'[attempt {attempt+1}/{self._RETRY_ATTEMPTS}] Suspicious symbols detected, skipping the current translation attempt.')  
+                    continue 
+                
                 # 4) 解析 response  
                 #    直接在这里进行解析 + 校验，不通过则抛异常  
                 # 4) Parse response  

--- a/server/instance.py
+++ b/server/instance.py
@@ -7,20 +7,6 @@ from pydantic import BaseModel
 from manga_translator import Config
 from server.sent_data_internal import fetch_data_stream, NotifyType, fetch_data
 
-import socket
-
-def get_local_ip():
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.connect(("8.8.8.8", 80))
-        ip = s.getsockname()[0]
-        s.close()
-        return ip
-    except Exception as e:
-        print(f"Error getting local IP: {e}")
-        return None
-
-
 class ExecutorInstance(BaseModel):
     ip: str
     port: int
@@ -30,13 +16,9 @@ class ExecutorInstance(BaseModel):
         self.busy = False
 
     async def sent(self, image: Image, config: Config):
-        self.ip = get_local_ip()
-        print(f"self.ip={self.ip}")
         return await fetch_data("http://"+self.ip+":"+str(self.port)+"/simple_execute/translate", image, config)
 
     async def sent_stream(self, image: Image, config: Config, sender: NotifyType):
-        self.ip = get_local_ip()
-        print(f"self.ip={self.ip}")
         await fetch_data_stream("http://"+self.ip+":"+str(self.port)+"/execute/translate", image, config, sender)
 
 class Executors:

--- a/server/main.py
+++ b/server/main.py
@@ -202,7 +202,7 @@ if __name__ == '__main__':
     proc = prepare(args)
     print("Nonce: "+nonce)
     try:
-        uvicorn.run(app, host=args.host, port=args.port, ssl_keyfile="key.pem", ssl_certfile="cert.pem")
+        uvicorn.run(app, host=args.host, port=args.port)
     except Exception:
         if proc:
             proc.terminate()


### PR DESCRIPTION
- 解决boder没对齐的问题，render超出边框问题等，测试后运行良好，代码的双语注释使用AI生成，如有误敬请谅解
Resolved the issue of misaligned borders and render overflow problems; tested and running smoothly. Bilingual comments in the code are generated by AI, apologies for any inaccuracies.

- 跳过出现幻觉时频繁出现的自定义字符
Skip common hallucination characters in specific models（test with ds-v3-0324）
![image](https://github.com/user-attachments/assets/1ba70860-1466-42b9-8254-62c0b98ab81b)

- 在进行render时，若字符完全在画布上方或下方(不应该出现，仍需解决)， paste_y_start 等于 paste_y_end ，切片 paste_y_start:paste_y_end 会产生高度为0的区域。现在直接跳过有问题的字符。
During rendering, if a character is entirely above or below the canvas (which should not occur but still needs to be resolved), paste_y_start equals paste_y_end, and the slice paste_y_start:paste_y_end will produce a region with a height of 0. Now directly skipping the problematic character.

- 增加特殊串行情况的检查。如果译文中某个序号对应的文本出现了仅存在标点符号或单个字符的情况，而对应的序号的源文却没出现相同的标点符号或单个字符。则这个标点符号或单个字符是凭空创造的。意味着翻译文本中必然有多行文本被合并了。
Add checks for special serial cases. If the text corresponding to a certain sequence number in the translation contains only punctuation or a single character, while the source text for the same sequence number does not have the same punctuation or single character, then this punctuation or single character is artificially created. This indicates that multiple lines of text in the translation must have been merged.
例子 / Example：
<|1|>How is the weather today.
<|2|>Oh
<|3|>It's sunny.
<|1|>今天天气怎么样？
<|2|>噢，阳光明媚
<|3|>！
第三个句子翻译返回了一个问号。源文两个句子被合并了，但是结果却通过了。
The third sentence translation returned "!". The source text's two sentences were merged, yet the result passed.

- 长句返回多个短句时合并翻译 / Merge translations when long sentences return multiple short sentences.
例子 / Example：
<|1|>"Despite the heavy rain pouring outside, she decided to go for a run anyway, grabbing her waterproof jacket and tying her hair up in a quick ponytail, determined not to let the gloomy weather ruin her daily exercise routine."
<|1|>外面下着大雨，
<|2|>但她还是决定去跑步，
<|3|>抓起防水外套，
<|4|>随手扎了个马尾，
<|5|>决心不让阴雨天打乱她的锻炼计划。

- 检查翻译文本的前缀是否正常
Check if the prefix of the translated text is normal.

- 解决无气泡的文本翻译后各自居中排布导致翻译后的文本上下乱蹿无法和其他文本对齐
Text without bubbles causes translated versions to center-align individually, making them jump up and down and fail to align with other text.

- 遇到左右不匹配的括号自动纠错及删除
Automatically correct or delete mismatched bracket.

TODO:
增加翻译结果检查，处理整体翻译结果的语言非目标语言的问题或个别长句返回源文语言或其他非目标语言的问题
Add translation result checking to address issues where the overall translation is not in the target language or individual long sentences return the source language or a non-target language.