### PR TITLE
Revert frontend <> server https communication to http

### DIFF
--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "https://localhost:8000",
+        target: "http://localhost:8000",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
         secure: false,


### PR DESCRIPTION
follow up change for #904

now that the backend server no longer require https, frontend should use http instead.