### PR TITLE
Fix: Text filtered when using the none translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,11 +976,11 @@ FIL: Filipino (Tagalog)
 | papago        |         |         |                                                          |
 | sakura        |         |         | Requires `SAKURA_API_BASE`                               |
 | custom openai |         |         | Requires  `CUSTOM_OPENAI_API_BASE` `CUSTOM_OPENAI_MODEL` |
-| offline       |         | ✔️      | Use the most suitable offline translator for the language    |
+| offline       |         | ✔️      | Use the most suitable offline translator for the language  |
 | sugoi         |         | ✔️      | Sugoi V4.0 model                                         |
 | m2m100        |         | ✔️      | Supports all languages                                   |
 | m2m100_big    |         | ✔️      |                                                          |
-| none          |         | ✔️      | Translate to empty text                                 |
+| <s>none</s>   |         | ✔️      | <s>Translate to empty text </s> Use the `--prep-manual` option instead |
 | original      |         | ✔️      | Keep original text                                      |
 
 -   API Key: Indicates whether the translator requires API keys to be set as environment variables.

--- a/README.md
+++ b/README.md
@@ -976,11 +976,11 @@ FIL: Filipino (Tagalog)
 | papago        |         |         |                                                          |
 | sakura        |         |         | Requires `SAKURA_API_BASE`                               |
 | custom openai |         |         | Requires  `CUSTOM_OPENAI_API_BASE` `CUSTOM_OPENAI_MODEL` |
-| offline       |         | ✔️      | Use the most suitable offline translator for the language  |
+| offline       |         | ✔️      | Use the most suitable offline translator for the language|
 | sugoi         |         | ✔️      | Sugoi V4.0 model                                         |
 | m2m100        |         | ✔️      | Supports all languages                                   |
 | m2m100_big    |         | ✔️      |                                                          |
-| <s>none</s>   |         | ✔️      | <s>Translate to empty text </s> Use the `--prep-manual` option instead |
+| none          |         | ✔️      | Translate to empty text                                  |
 | original      |         | ✔️      | Keep original text                                      |
 
 -   API Key: Indicates whether the translator requires API keys to be set as environment variables.

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -615,14 +615,8 @@ class MangaTranslator:
                 region.translation = ""  # 空翻译将创建空白区域 / Empty translation will create blank areas  
                 region.target_lang = config.translator.target_lang  
                 region._alignment = config.render.alignment  
-                region._direction = config.render.direction   
-            
-            # 如果有prep_manual标志，则保留所有文本区域不进行过滤  
-            # If prep_manual flag is present, keep all text regions without filtering  
-            if self.prep_manual:  
-                return ctx.text_regions  
-            # 如果没有prep_manual标志，继续执行后续代码进行过滤  
-            # If no prep_manual flag, continue to filtering logic below  
+                region._direction = config.render.direction    
+            return ctx.text_regions  
 
         # 以下翻译处理仅在非none翻译器或有none翻译器但没有prep_manual时执行  
         # Translation processing below only happens for non-none translator or none translator without prep_manual  


### PR DESCRIPTION
Fix: https://github.com/zyddnys/manga-image-translator/issues/933