### PR TITLE
feat: add context-aware translation for openai;  Fix: Font blurring

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Colorizer: **mc2**
 --pre-dict PRE_DICT            Path to the pre-translation replacement dictionary file
 --post-dict POST_DICT          Path to the post-translation replacement dictionary file
 --kernel-size KERNEL_SIZE      Set the kernel size for the convolution of text erasure area to completely clear residual text
+--context-size                 Pages of context are needed for translating the current page. currently, this only applies to openaitranslator. 
 ```
 #### Additional Options
 ##### Local Mode Options

--- a/README_CN.md
+++ b/README_CN.md
@@ -396,6 +396,7 @@ OCR：
 --pre-dict PRE_DICT            翻译前替换字典文件路径
 --post-dict POST_DICT          翻译后替换字典文件路径
 --kernel-size KERNEL_SIZE      设置文本擦除区域的卷积内核大小以完全清除文本残留
+--context-size                 上<s>下</s>文页数（暂时仅对openaitranslator有效）
 ```
 #### 附加参数
 ##### 本地模式参数

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -93,7 +93,7 @@ def general_parser(g_parser):
                         help='Path to the post-translation dictionary file')
     g_parser.add_argument('--kernel-size', default=3, type=int,
                         help='Set the convolution kernel size of the text erasure area to completely clean up text residues')
-
+    g_parser.add_argument('--context-size', default=0, type=int, help='Pages of context are needed for translating the current page')
 
 
 def reparse(arr: list):

--- a/manga_translator/manga_translator.py
+++ b/manga_translator/manga_translator.py
@@ -131,7 +131,9 @@ class MangaTranslator:
         self._model_usage_timestamps = {}
         self._detector_cleanup_task = None
         self.prep_manual = params.get('prep_manual', None)
-        
+        self.context_size = params.get('context_size', 0)
+        self.all_page_translations = []
+
     def parse_init_params(self, params: dict):
         self.verbose = params.get('verbose', False)
         self.use_mtpe = params.get('use_mtpe', False)
@@ -600,6 +602,85 @@ class MangaTranslator:
         
         return text_regions
 
+    def _build_prev_context(self):   
+        """
+        跳过句子数为0的页面，取最近 context_size 个非空页面，拼成：
+        <|1|>句子
+        <|2|>句子
+        ...
+        的格式；如果没有任何非空页面，返回空串。
+        """
+        if self.context_size <= 0 or not self.all_page_translations:
+            return ""
+        # 筛选出有句子的页面
+        non_empty_pages = [
+            page for page in self.all_page_translations
+            if any(sent.strip() for sent in page.values())
+        ]
+        # 实际要用的页数
+        pages_used = min(self.context_size, len(non_empty_pages))
+        if pages_used == 0:
+            return ""
+        tail = non_empty_pages[-pages_used:]
+        # 拼接
+        lines = []
+        for page in tail:
+            for sent in page.values():
+                if sent.strip():
+                    lines.append(sent.strip())
+        numbered = [f"<|{i+1}|>{s}" for i, s in enumerate(lines)]
+        return "Here are the previous translation results for reference:\n" + "\n".join(numbered)
+
+    async def _dispatch_with_context(self, config: Config, texts: list[str], ctx: Context):
+        # 计算实际要使用的上下文页数和跳过的空页数
+        # Calculate the actual number of context pages to use and empty pages to skip
+        done_pages = self.all_page_translations
+        if self.context_size > 0 and done_pages:
+            pages_expected = min(self.context_size, len(done_pages))
+            non_empty_pages = [
+                page for page in done_pages
+                if any(sent.strip() for sent in page.values())
+            ]
+            pages_used = min(self.context_size, len(non_empty_pages))
+            skipped = pages_expected - pages_used
+        else:
+            pages_used = skipped = 0
+
+        if self.context_size > 0:
+            logger.info(f"Context-aware translation enabled with {self.context_size} pages of history")
+
+        # 构建上下文字符串
+        # Build the context string
+        prev_ctx = self._build_prev_context()
+
+        # 如果是 ChatGPT 翻译器，则专门处理上下文注入
+        # Special handling for ChatGPT translator: inject context
+        if config.translator.translator == Translator.chatgpt:
+            from .translators.chatgpt import OpenAITranslator
+            translator = OpenAITranslator()
+            translator.set_prev_context(prev_ctx)
+
+            if pages_used > 0:
+                context_count = prev_ctx.count("<|")
+                logger.info(f"Carrying {pages_used} pages of context, {context_count} sentences as translation reference")
+            if skipped > 0:
+                logger.warning(f"Skipped {skipped} pages with no sentences")
+                
+            return await translator._translate(
+                ctx.from_lang,          
+                config.translator.target_lang, 
+                texts
+            )
+
+        return await dispatch_translation(
+            config.translator.translator_gen,
+            texts,
+            config.translator,
+            self.use_mtpe,
+            ctx,
+            'cpu' if self._gpu_limited_memory else self.device
+        )
+
     async def _run_text_translation(self, config: Config, ctx: Context):
         # 如果设置了prep_manual则将translator设置为none，防止token浪费
         # Set translator to none to provent token waste if prep_manual is True  
@@ -631,12 +712,11 @@ class MangaTranslator:
             # 如果是none翻译器，不需要调用翻译服务，文本已经设置为空  
             # If using none translator, no need to call translation service, text is already set to empty  
             if config.translator.translator != Translator.none:  
+                # 自动给 ChatGPT 加上下文，其他翻译器不改变
+                # Automatically add context to ChatGPT, no change for other translators
+                texts = [region.text for region in ctx.text_regions]
                 translated_sentences = \
-                    await dispatch_translation(config.translator.translator_gen,  
-                                              [region.text for region in ctx.text_regions],  
-                                              config.translator,  
-                                              self.use_mtpe,  
-                                              ctx, 'cpu' if self._gpu_limited_memory else self.device)  
+                    await self._dispatch_with_context(config, texts, ctx)
             else:  
                 # 对于none翻译器，创建一个空翻译列表  
                 # For none translator, create an empty translation list  
@@ -743,6 +823,12 @@ class MangaTranslator:
                 for v in replace_items:
                     region.translation = region.translation.replace(v[1], v[0])
 
+        # 汇总本页翻译，供下一页做上文
+        # Collect translations for the current page to use as "previous context" for the next page
+        page_translations = {r.text_raw if hasattr(r, "text_raw") else r.text: r.translation
+                             for r in ctx.text_regions}
+        self.all_page_translations.append(page_translations)
+
         # Apply post dictionary after translating
         post_dict = load_dictionary(self.post_dict)
         post_replacements = []  
@@ -843,7 +929,7 @@ class MangaTranslator:
                 if region in has_target_lang_in_translation_regions:  
                     new_text_regions.append(region)  
                 else:  
-                    if config.translator.translator == Translator.none and not region.translation.strip():  
+                    if config.translator == Translator.none and not region.translation.strip():  
                         logger.info(f'Filtered out: {region.translation}')  
                         logger.info('Reason: Translation contain blank areas')  
                     else:  

--- a/manga_translator/rendering/text_render.py
+++ b/manga_translator/rendering/text_render.py
@@ -91,7 +91,7 @@ def compact_special_symbols(text: str) -> str:
     text = re.sub(pattern, r'\1', text) 
     return text
     
-def rotate_image(image, angle):
+def rotate_image(image, angle, upscale_ratio=None):
     if angle == 0:
         return image, (0, 0)
     image_exp = np.zeros((round(image.shape[0] * 1.5), round(image.shape[1] * 1.5), image.shape[2]), dtype = np.uint8)
@@ -101,7 +101,8 @@ def rotate_image(image, angle):
     # from https://stackoverflow.com/questions/9041681/opencv-python-rotate-image-by-x-degrees-around-specific-point
     image_center = tuple(np.array(image_exp.shape[1::-1]) / 2)
     rot_mat = cv2.getRotationMatrix2D(image_center, angle, 1.0)
-    result = cv2.warpAffine(image_exp, rot_mat, image_exp.shape[1::-1], flags=cv2.INTER_LINEAR)
+    interpolation = cv2.INTER_LINEAR if upscale_ratio else cv2.INTER_NEAREST
+    result = cv2.warpAffine(image_exp, rot_mat, image_exp.shape[1::-1], flags=interpolation)
     if angle == 90:
         return result, (0, 0)
     return result, (diff_i, diff_j)

--- a/manga_translator/translators/config_gpt.py
+++ b/manga_translator/translators/config_gpt.py
@@ -153,8 +153,8 @@ class ConfigGPT:
 
     _JSON_MODE=False
 
-    _PROMPT_TEMPLATE = ('Please help me to translate the following text from a manga to {to_lang}.'
-                        'If it\'s already in {to_lang} or looks like gibberish'
+    _PROMPT_TEMPLATE = ('Please help me to translate the following text from a manga to {to_lang}. '
+                        'If it\'s already in {to_lang} or looks like gibberish '
                         'you have to output it as it is instead. Keep prefix format.\n'
                     )
                     
@@ -253,9 +253,12 @@ class ConfigGPT:
         if self.langSamples is not None:
             return self.langSamples
         
-        self.langSamples=[]
+        self.langSamples = []
 
         try:
+            if to_lang in self._LANGUAGE_CODE_MAP:
+                to_lang = self._LANGUAGE_CODE_MAP[to_lang]
+
             foundLang = closest_supported_match(
                                 Language.find(to_lang), 
                                 [


### PR DESCRIPTION
add `--context-size` as basic option
Only the preceding text can be referenced, not the following text
example:
```
[local] Context-aware translation enabled with 2 pages of history
[local] Carrying 1 pages of context, 2 sentences as translation reference
SYSTEM:
Here are the previous translation results for reference:
<|1|>a
<|2|>b
```

```
[local] Context-aware translation enabled with 2 pages of history
[local] Carrying 2 pages of context, 3 sentences as translation reference
[local] Skipped 1 pages with no sentences
SYSTEM:
Here are the previous translation results for reference:
<|1|>a
<|2|>b
<|3|>c
```
fix https://github.com/zyddnys/manga-image-translator/issues/961
Use `INTER_NEAREST` instead of `INTER_LINEAR` to reduce text blurring when the upscaler is not in use, but the aliasing issue will be more severe. haven't found a balance yet.