### PR TITLE
Refactored paddle.py

### DIFF
--- a/manga_translator/detection/__init__.py
+++ b/manga_translator/detection/__init__.py
@@ -36,10 +36,7 @@ async def dispatch(detector_key: Detector, image: np.ndarray, detect_size: int, 
                    invert: bool, gamma_correct: bool, rotate: bool, auto_rotate: bool = False, device: str = 'cpu', verbose: bool = False):
     detector = get_detector(detector_key)
     if isinstance(detector, OfflineDetector):
-        if isinstance(detector, PaddleDetector):
-            await detector.load(device, text_threshold=text_threshold, box_threshold=box_threshold, unclip_ratio=unclip_ratio, invert=invert, verbose=verbose)
-        else:
-            await detector.load(device)
+        await detector.load(device)
     return await detector.detect(image, detect_size, text_threshold, box_threshold, unclip_ratio, invert, gamma_correct, rotate, auto_rotate, verbose)
 
 async def unload(detector_key: Detector):

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,6 +63,8 @@ regex
 # Let pip choose the cuda version to use:
 --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu118/
 --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu123/
+--extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/
+--extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu129/
 paddleocr
 paddlepaddle
 paddlepaddle-gpu; sys_platform != 'darwin'


### PR DESCRIPTION
重写了文本检测部分的paddle.py程序，使用paddle的专用文本检测模块代替原有的ocr模块，并优化了调用逻辑，现在的load函数以及infer函数的参数与default保持一致。
现在的问题：无法使用gpu模式，似乎是因为pytorch使用的cuda版本与paddle使用的cuda版本不一致导致的，这一点我暂时无法解决。cpu模式可以正常使用。

Rewrote the paddle.py program for text detection, using Paddle's dedicated text detection module instead of the original OCR module, and optimized the call logic. The parameters of the current load function and infer function are consistent with the default.
The current issue: unable to use GPU mode, seemingly because the CUDA version used by PyTorch is inconsistent with the CUDA version used by Paddle, which I cannot resolve for the time being. CPU mode works normally.