### PR TITLE
Fixing arabic from LTR to RTL . hance that Arabic is RLT

### DIFF
--- a/manga_translator/translators/common.py
+++ b/manga_translator/translators/common.py
@@ -210,8 +210,8 @@ class CommonTranslator(InfererModule):
         translations = [self._clean_translation_output(q, r, to_lang) for q, r in zip(queries, translations)]
 
         if to_lang == 'ARA':
-            import arabic_reshaper
-            translations = [arabic_reshaper.reshape(t) for t in translations]
+            import arabic_reshaper ,bidi.algorithm
+            translations = [bidi.algorithm.get_display(arabic_reshaper.reshape(t)) for t in translations]
 
         if use_mtpe:
             translations = await self.mtpe_adapter.dispatch(queries, translations)

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,4 @@ regex
 paddleocr
 paddlepaddle
 paddlepaddle-gpu; sys_platform != 'darwin'
+python-bidi


### PR DESCRIPTION
The algorithm was already written, but I added display support using bidi.algorithm to render Arabic text correctly in the translation output.
Here are two images showing the difference before and after the change:

Before
<img width="735" height="1106" alt="final" src="https://github.com/user-attachments/assets/8e0e8227-518e-48c9-a4a1-73977cb12c9e" />

After
<img width="735" height="1106" alt="final" src="https://github.com/user-attachments/assets/280adb5d-f2e0-4de2-b2b7-c26c9ebfd56d" />

This change transforms the interface from unusable to usable for Arabic-speaking users, although further enhancements are still needed.

This is my first time contributing to an open-source project, so I don't expect this change to go to production—but I'm proud to take the first step! 😊