### PR TITLE
supporting Arabic , RTL support

### DIFF
--- a/manga_translator/translators/common.py
+++ b/manga_translator/translators/common.py
@@ -210,8 +210,8 @@ class CommonTranslator(InfererModule):
         translations = [self._clean_translation_output(q, r, to_lang) for q, r in zip(queries, translations)]
 
         if to_lang == 'ARA':
-            import arabic_reshaper
-            translations = [arabic_reshaper.reshape(t) for t in translations]
+            import arabic_reshaper , bidi.algorithm
+            translations = [bidi.algorithm.get_display(arabic_reshaper.reshape(t)) for t in translations]
 
         if use_mtpe:
             translations = await self.mtpe_adapter.dispatch(queries, translations)

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,4 @@ rich
 regex
 --extra-index-url https://frederik-uni.github.io/manga-image-translator-rust/python/wheels/simple/
 rusty-manga-image-translator
+python-bidi


### PR DESCRIPTION
This 3-line change adds proper support for Arabic text rendering by switching the direction from LTR to RTL.

Before:
<img width="735" height="1106" alt="Before - Arabic text rendered incorrectly (LTR)" src="https://github.com/user-attachments/assets/f1c296c8-efda-4d7c-9246-8d658b11c90a" />

After:
<img width="735" height="1106" alt="After - Arabic text rendered correctly (RTL)" src="https://github.com/user-attachments/assets/eccbfe2b-de6a-494b-8e13-2e2a9ef9c515" />

As you can see, the previous rendering displayed Arabic text in the wrong direction, making it hard to understand. This fix ensures the layout follows the natural right-to-left direction of Arabic, improving readability and usability.

Note:
This is my second attempt to submit this fix. The previous PR had a merge conflict in requirements.txt that I wasn't sure how to resolve, so I’ve submitted a new pull request with just the necessary changes.

