### PR TITLE
替换字典功能报错

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -256,10 +256,10 @@ def start_translator_client_proc(host: str, port: int, nonce: str, params: Names
         cmds.append('--verbose')
     if params.models_ttl:
         cmds.append('--models-ttl=%s' % params.models_ttl)
-    if params.pre_dict: 
-        cmds.extend(['--pre-dict', params.pre_dict]) 
-    if params.pre_dict: 
-        cmds.extend(['--post-dict', params.post_dict])         
+    if getattr(params, 'pre_dict', None):
+        cmds.extend(['--pre-dict', params.pre_dict])
+    if getattr(params, 'post_dict', None):
+        cmds.extend(['--post-dict', params.post_dict])       
     base_path = os.path.dirname(os.path.abspath(__file__))
     parent = os.path.dirname(base_path)
     proc = subprocess.Popen(cmds, cwd=parent)


### PR DESCRIPTION
params.post_dict拼写错误，写成了params.pre_dict