### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ numpy==1.26.4
 tensorboardX
 websockets
 protobuf<6.0.0,>=3.20.2 # `google-genai` dependancy requirement
-ctranslate2<=3.24.0 # last version compatible with CUDA 11
+ctranslate2
 colorama
 openai==1.63.0
 tiktoken


### PR DESCRIPTION
Updating `ctranslate2<=3.24.0` to `ctranslate2` since that version might no longer working. 
`ctranslate2<=3.24.0` gives this error:

```
Traceback (most recent call last):
  File "~/.pyenv/versions/3.10.6/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "~/.pyenv/versions/3.10.6/lib/python3.10/runpy.py", line 146, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "~/.pyenv/versions/3.10.6/lib/python3.10/runpy.py", line 110, in _get_module_details
    __import__(pkg_name)
  File "~/manga-image-translator/manga_translator/__init__.py", line 7, in <module>
    from .manga_translator import *
  File "~/manga-image-translator/manga_translator/manga_translator.py", line 36, in <module>
    from .translators import (
  File "~/manga-image-translator/manga_translator/translators/__init__.py", line 16, in <module>
    from .sugoi import JparacrawlTranslator, JparacrawlBigTranslator, SugoiTranslator
  File "~/manga-image-translator/manga_translator/translators/sugoi.py", line 1, in <module>
    import ctranslate2
  File "~/manga-image-translator/venv/lib/python3.10/site-packages/ctranslate2/__init__.py", line 21, in <module>
    from ctranslate2._ext import (
ImportError: libctranslate2-1e22bce9.so.3.24.0: cannot enable executable stack as shared object requires: Invalid argument
```