### PR TITLE
fix: prevent IndexError when LLM response lacks translation delimiter in custom_openai

### DIFF
--- a/manga_translator/translators/custom_openai.py
+++ b/manga_translator/translators/custom_openai.py
@@ -183,10 +183,14 @@ class CustomOpenAiTranslator(ConfigGPT, CommonTranslator):
             new_translations = re.split(r'<\|\d+\|>', 'pre_1\n' + response)[1:]
             # new_translations = re.split(r'<\|\d+\|>', response)
 
+            # When there is only one query LLMs likes to exclude the <|1|>
+            if not new_translations:
+                new_translations = [response]
+
             # Immediately clean leading and trailing whitespace from each translation text
             new_translations = [t.strip() for t in new_translations]
 
-            # When there is only one query LLMs likes to exclude the <|1|>
+            # When there is only one query LLMs likes to exclude the <|1|> # Maybe it can be removed, but it causes no errors
             if not new_translations[0].strip():
                 new_translations = new_translations[1:]
 


### PR DESCRIPTION
### Summary

Fixes an `IndexError: list index out of range` that occurs when an LLM response for a single translation does not contain the expected `<|1|>` delimiter.

### Root Cause

The current code always expects the `re.split(r'<\|\d+\|>', ...)` operation to result in a list with at least one element after applying `[1:]`. However, if the `response` string contains no delimiter (which happens with single-query responses), the operation `re.split(...)[1:]` results in an empty list `[]`. The subsequent attempt to access `new_translations[0]` then throws an `IndexError`.

### Changes

After `re.split`, change `new_translations` to `[response]` if `new_translations` has no items.