### PR TITLE
Add batch processing to WebUI

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -368,6 +368,40 @@
                 Click the empty space or paste/drag a new one to replace
               </div>
             </div>
+            <!-- 複数ファイルが選択された場合 -->
+            <div v-else-if="selectedFiles.length > 0" class="flex flex-col items-center gap-4 text-center">
+              <i class="iconify w-8 h-8 text-blue-500" data-icon="carbon:document-multiple"></i>
+              <div class="text-gray-700">
+                <span class="font-medium">{{ selectedFiles.length }}</span> files selected
+              </div>
+              <div class="max-h-32 overflow-y-auto w-full">
+                <div v-for="file in selectedFiles.slice(0, 5)" :key="file.name"
+                     class="text-sm text-gray-600 truncate px-2 py-1 bg-gray-50 rounded">
+                  {{ file.name }}
+                </div>
+                <div v-if="selectedFiles.length > 5" class="text-sm text-gray-500">
+                  ... and {{ selectedFiles.length - 5 }} more files
+                </div>
+              </div>
+              <div class="flex space-x-2">
+                <button
+                  type="button"
+                  @click="clearSelectedFiles"
+                  class="px-3 py-1 bg-gray-600 text-white rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  style="color: white !important; background-color: #4B5563 !important;"
+                >
+                  Clear
+                </button>
+                <button
+                  type="button"
+                  @click="addSelectedFilesToQueue"
+                  class="px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+                  style="color: white !important; background-color: #2563EB !important;"
+                >
+                  Add to Queue
+                </button>
+              </div>
+            </div>
             <!-- まだファイルがない場合 -->
             <div v-else class="flex flex-col items-center gap-2 text-center">
 
@@ -380,6 +414,20 @@
               </div>
               <div class="text-sm text-gray-500">
                 Supports multiple file selection (Ctrl/Cmd + click)
+              </div>
+              <div class="flex space-x-2 mt-2">
+                <button
+                  @click="selectMultipleFiles"
+                  class="px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm transition-colors">
+                  <i class="iconify inline-block mr-1" data-icon="carbon:folder-add"></i>
+                  Multiple Files
+                </button>
+                <button
+                  @click="selectFolder"
+                  class="px-3 py-1 bg-purple-600 text-white rounded-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 text-sm transition-colors">
+                  <i class="iconify inline-block mr-1" data-icon="carbon:folder"></i>
+                  Folder
+                </button>
               </div>
             </div>
             
@@ -430,36 +478,6 @@
           </a>
         </div>
 
-        <!-- Batch Upload Section -->
-        <div class="border-t pt-6 mt-6">
-          <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-semibold text-gray-800">
-              Batch Upload
-            </h3>
-          </div>
-          
-          <div class="flex flex-col items-center space-y-4 p-6 border-2 border-dashed border-gray-300 rounded-lg hover:border-blue-400 transition-colors">
-            <i class="iconify w-12 h-12 text-gray-400" data-icon="carbon:batch-job"></i>
-            <div class="text-center">
-              <p class="text-gray-600 mb-2">Upload multiple images at once</p>
-              <p class="text-sm text-gray-500">Select multiple files or drag & drop a group of images</p>
-            </div>
-            <div class="flex space-x-3">
-              <button
-                @click="selectMultipleFiles"
-                class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors">
-                <i class="iconify inline-block mr-2" data-icon="carbon:folder-add"></i>
-                Select Multiple Files
-              </button>
-              <button
-                @click="selectFolder"
-                class="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-500 transition-colors">
-                <i class="iconify inline-block mr-2" data-icon="carbon:folder"></i>
-                Select Folder
-              </button>
-            </div>
-          </div>
-        </div>
 
         <!-- Image Queue Section -->
         <div class="border-t pt-6 mt-6">
@@ -754,6 +772,7 @@
         queuedImages: [],
         finishedImages: [],
         showGallery: false,
+        selectedFiles: [], // Store multiple selected files before adding to queue
         
         // Gallery modal
         selectedImage: null,
@@ -887,12 +906,14 @@
           const files = Array.from(e.dataTransfer?.files || []);
           const validFiles = files.filter(file => acceptTypes.includes(file.type));
           
-          if (validFiles.length === 1 && !this.file) {
-            // Single file and no current file - maintain existing behavior
+          if (validFiles.length === 1 && !this.file && this.selectedFiles.length === 0) {
+            // Single file and no current file or selected files - maintain existing behavior
             this.file = validFiles[0];
+            this.selectedFiles = []; // Clear any selected files
           } else if (validFiles.length > 0) {
-            // Multiple files or single file when already have one - add to queue
-            this.addMultipleFilesToQueue(validFiles);
+            // Multiple files or single file when already have files - store for preview
+            this.selectedFiles = validFiles;
+            this.file = null; // Clear single file
           }
         },
         onfilechange(e) {
@@ -902,9 +923,11 @@
           if (validFiles.length === 1) {
             // Single file - maintain existing behavior
             this.file = validFiles[0];
+            this.selectedFiles = []; // Clear any selected files
           } else if (validFiles.length > 1) {
-            // Multiple files - add all to queue
-            this.addMultipleFilesToQueue(validFiles);
+            // Multiple files - store them for preview, don't add to queue yet
+            this.selectedFiles = validFiles;
+            this.file = null; // Clear single file
             // Clear the file input
             e.target.value = '';
           }
@@ -922,18 +945,31 @@
             }
           }
           
-          if (pastedFiles.length === 1 && !this.file) {
-            // Single file and no current file - maintain existing behavior
+          if (pastedFiles.length === 1 && !this.file && this.selectedFiles.length === 0) {
+            // Single file and no current file or selected files - maintain existing behavior
             this.file = pastedFiles[0];
+            this.selectedFiles = []; // Clear any selected files
           } else if (pastedFiles.length > 0) {
-            // Multiple files or single file when already have one - add to queue
-            this.addMultipleFilesToQueue(pastedFiles);
+            // Multiple files or single file when already have files - store for preview
+            this.selectedFiles = pastedFiles;
+            this.file = null; // Clear single file
           }
         },
 
         // Queue management
         clearFile() {
           this.file = null;
+        },
+
+        clearSelectedFiles() {
+          this.selectedFiles = [];
+        },
+
+        addSelectedFilesToQueue() {
+          if (this.selectedFiles.length > 0) {
+            this.addMultipleFilesToQueue(this.selectedFiles);
+            this.selectedFiles = [];
+          }
         },
 
         // Add multiple files to queue
@@ -984,7 +1020,8 @@
             const validFiles = files.filter(file => acceptTypes.includes(file.type));
             
             if (validFiles.length > 0) {
-              this.addMultipleFilesToQueue(validFiles);
+              this.selectedFiles = validFiles;
+              this.file = null; // Clear single file
             }
           };
           
@@ -1004,7 +1041,8 @@
             const validFiles = files.filter(file => acceptTypes.includes(file.type));
             
             if (validFiles.length > 0) {
-              this.addMultipleFilesToQueue(validFiles);
+              this.selectedFiles = validFiles;
+              this.file = null; // Clear single file
             }
           };
           


### PR DESCRIPTION
Sorry for the slop

This pull request significantly enhances the file upload experience in `server/index.html` by adding support for multiple file selection, preview, and batch queueing. Users can now select, preview, and add multiple images (or entire folders) to the processing queue at once, improving usability for bulk operations. The UI and logic have been updated to clearly distinguish between single and multiple file workflows.

Key changes include:

**Multiple File Selection and Preview UI:**
- Added a new UI section that appears when multiple files are selected, showing a preview of up to five files, the total count, and options to clear or add the selection to the queue.
- Updated the instructions and buttons to clarify multi-file support, including new buttons for selecting multiple files or folders.
- Enabled the `multiple` attribute on the main file input to allow users to select multiple files at once.

**Batch File Handling Logic:**
- Introduced a `selectedFiles` data property to store multiple files before queueing.
- Updated event handlers for drop, file input change, and paste events to support and distinguish between single and multiple file selection, updating `file` and `selectedFiles` accordingly.

**Batch Queue Management:**
- Added functions to clear selected files, add multiple files to the queue, and handle batch processing logic, including support for folder selection and batch uploads.

These changes make it much easier to work with multiple images, especially for users who need to process batches or entire folders of files at once.