### PR TITLE
fix #1032: use of host ip `0.0.0.0` causing `ExecutorInstance` behave abnormally

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -263,6 +263,8 @@ def start_translator_client_proc(host: str, port: int, nonce: str, params: Names
     base_path = os.path.dirname(os.path.abspath(__file__))
     parent = os.path.dirname(base_path)
     proc = subprocess.Popen(cmds, cwd=parent)
+    if host in ('0.0.0.0', '::/0'):
+        host = '127.0.0.1'
     executor_instances.register(ExecutorInstance(ip=host, port=port))
 
     def handle_exit_signals(signal, frame):


### PR DESCRIPTION
This pr closes #1032.
Use of `--host=0.0.0.0` would cause translation core instance not callable by `ExecutorInstance`, under such situation, server instance should use `127.0.0.1` to access core instance internally instead.