### PR TITLE
Optimize Docker build speed using BuildKit cache for models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,10 @@ RUN export TZ=Etc/UTC \
 COPY . /app
 
 # Prepare models
-RUN python -u docker_prepare.py --continue-on-error
+RUN --mount=type=cache,target=/.cache/models \
+    cp -rn /.cache/models/. /app/models/ || true && \
+    python -u docker_prepare.py --continue-on-error && \
+    cp -rn /app/models/. /.cache/models/ || true
 
 RUN rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp
 


### PR DESCRIPTION
 ### Description
Previously, while building docker image after code changes, the models will be downloaded repeatedly regardless the models were changed or not.
This PR introduces Docker BuildKit mount caching to the model preparation stage. This significantly reduces rebuild times by persisting downloaded/prepared models between builds.

### Changes
- Added `mount=type=cache,target=/.cache/models` to the model preparation step.
- Implemented a bi-directional sync between the cache mount and the `/app/models` directory:
  1. Restore existing models from cache to `/app/models` before running the preparation script.
  2. Run `docker_prepare.py` to download/process any missing models. Existing models will not be downloaded.
  3. Sync newly acquired models back to the cache for future builds.
- Used `cp -rn` and `|| true` to ensure the build remains robust even if cache operations encounter minor issues.

