### PR TITLE
Restore shared API mode, fix CVE-2026-26215 by implementing the proposed patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ ws                  run in WebSocket mode
 shared              run in API mode
 --host HOST         Host of the API service (default: 127.0.0.1)
 --port PORT         Port of the API service (default: 5003)
---nonce NONCE       Nonce used to secure internal API server communication
+--nonce NONCE       Nonce used to secure internal API server communication, set to "None" to disable
 --report REPORT     Report to server to register instance (default: None)
 --models-ttl MODELS_TTL  TTL of models in memory in seconds (0 means forever)
 ```
@@ -452,7 +452,7 @@ shared              run in API mode
 --host HOST           Host address (default: 127.0.0.1)
 --port PORT           Port number (default: 8000)
 --start-instance      Whether an instance of the translator should be started automatically
---nonce NONCE         Nonce used to secure internal Web Server communication
+--nonce NONCE         Nonce used to secure internal Web Server communication, set to "None" to disable
 --models-ttl MODELS_TTL  Time in seconds to keep models in memory after last use (0 means forever)
 ```
 

--- a/manga_translator/__main__.py
+++ b/manga_translator/__main__.py
@@ -70,7 +70,9 @@ async def dispatch(args: Namespace):
         await translator.listen(args_dict)
 
     elif args.mode == 'shared':
-        raise Exception('Shared mode is currently not supported. Please use web mode instead.')
+        from manga_translator.mode.share import MangaShare
+        translator = MangaShare(args_dict)
+        await translator.listen(args_dict)
     elif args.mode == 'config-help':
         import json
         config = Config.schema()

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -141,7 +141,7 @@ parser_ws.add_argument('--models-ttl', default='0', type=int, help='How long to 
 parser_api = subparsers.add_parser('shared', help='Run in API mode')
 parser_api.add_argument('--host', default='127.0.0.1', type=str, help='Host for API service')
 parser_api.add_argument('--port', default=5003, type=int, help='Port for API service')
-parser_api.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE') or None, type=str, help='Nonce for securing internal API server communication')
+parser_api.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE') or None, type=str, help='Nonce for securing internal API server communication, set to "None" to disable')
 parser_api.add_argument("--report", default=None,type=str, help='reports to server to register instance')
 parser_api.add_argument('--models-ttl', default='0', type=int, help='models TTL in memory in seconds')
 

--- a/manga_translator/args.py
+++ b/manga_translator/args.py
@@ -133,7 +133,7 @@ parser_batch.add_argument('--config-file', default=None, type=str, help='path to
 parser_ws = subparsers.add_parser('ws', help='Run in WebSocket mode')
 parser_ws.add_argument('--host', default='127.0.0.1', type=str, help='Host for WebSocket service')
 parser_ws.add_argument('--port', default=5003, type=int, help='Port for WebSocket service')
-parser_ws.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE', ''), type=str, help='Nonce for securing internal WebSocket communication')
+parser_ws.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE') or None, type=str, help='Nonce for securing internal WebSocket communication')
 parser_ws.add_argument('--ws-url', default='ws://localhost:5000', type=str, help='Server URL for WebSocket mode')
 parser_ws.add_argument('--models-ttl', default='0', type=int, help='How long to keep models in memory in seconds after last use (0 means forever)')
 
@@ -141,7 +141,7 @@ parser_ws.add_argument('--models-ttl', default='0', type=int, help='How long to 
 parser_api = subparsers.add_parser('shared', help='Run in API mode')
 parser_api.add_argument('--host', default='127.0.0.1', type=str, help='Host for API service')
 parser_api.add_argument('--port', default=5003, type=int, help='Port for API service')
-parser_api.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE', ''), type=str, help='Nonce for securing internal API server communication')
+parser_api.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE') or None, type=str, help='Nonce for securing internal API server communication')
 parser_api.add_argument("--report", default=None,type=str, help='reports to server to register instance')
 parser_api.add_argument('--models-ttl', default='0', type=int, help='models TTL in memory in seconds')
 

--- a/manga_translator/mode/share.py
+++ b/manga_translator/mode/share.py
@@ -52,6 +52,8 @@ class MangaShare:
         nonce = params.get('nonce', None)
         if not nonce:
             nonce = secrets.token_hex(16)
+        if nonce == "None":
+            nonce = None
         self.nonce = nonce
 
         # each chunk has a structure like this status_code(int/1byte),len(int/4bytes),bytechunk

--- a/manga_translator/mode/share.py
+++ b/manga_translator/mode/share.py
@@ -18,15 +18,15 @@ SAFE_PICKLE_MODULES = frozenset({
     'numpy',
     'numpy.core.multiarray',
     'numpy.dtype',
-    'PIL.Image',
     'manga_translator',
     'manga_translator.utils',
     'manga_translator.utils.generic',
+    'manga_translator.config'
 })
 
 class RestrictedUnpickler(pickle.Unpickler):
     def find_class(self, module: str, name: str):
-        if module in SAFE_PICKLE_MODULES:
+        if module in SAFE_PICKLE_MODULES or module.startswith('PIL.'):
             return super().find_class(module, name)
         raise pickle.UnpicklingError(
             f"Deserialization of {module}.{name} is not allowed"

--- a/manga_translator/mode/share.py
+++ b/manga_translator/mode/share.py
@@ -1,0 +1,143 @@
+import asyncio
+import pickle
+from threading import Lock
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Path, Request, Response
+from pydantic import BaseModel
+
+from starlette.responses import StreamingResponse
+
+from manga_translator import MangaTranslator
+
+class MethodCall(BaseModel):
+    method_name: str
+    attributes: bytes
+
+
+
+
+
+class MangaShare:
+    def __init__(self, params: dict = None):
+        self.manga = MangaTranslator(params)
+        self.host = params.get('host', '127.0.0.1')
+        self.port = int(params.get('port', '5003'))
+        self.nonce = params.get('nonce', None)
+
+        # each chunk has a structure like this status_code(int/1byte),len(int/4bytes),bytechunk
+        # status codes are 0 for result, 1 for progress report, 2 for error
+        self.progress_queue = asyncio.Queue()
+        self.lock = Lock()
+
+        async def hook(state: str, finished: bool):
+            state_data = state.encode("utf-8")
+            progress_data = b'\x01' + len(state_data).to_bytes(4, 'big') + state_data
+            await self.progress_queue.put(progress_data)
+            await asyncio.sleep(0)
+
+        self.manga.add_progress_hook(hook)
+
+    async def progress_stream(self):
+        """
+        loops until the status is != 1 which is eiter an error or the result
+        """
+        while True:
+            progress = await self.progress_queue.get()
+            yield progress
+            if progress[0] != 1:
+                break
+
+    async def run_method(self, method, **attributes):
+        try:
+            if asyncio.iscoroutinefunction(method):
+                result = await method(**attributes)
+            else:
+                result = method(**attributes)
+
+            # 检查是否使用占位符，如果是则创建最小化的结果对象
+            if hasattr(result, 'use_placeholder') and result.use_placeholder:
+                # 创建一个最小的Context对象，只包含占位符图片，避免传输大量数据
+                from manga_translator import Context
+                from PIL import Image
+                minimal_result = Context()
+                minimal_result.result = Image.new('RGB', (1, 1), color='white')
+                minimal_result.use_placeholder = True
+                result_bytes = pickle.dumps(minimal_result)
+            else:
+                result_bytes = pickle.dumps(result)
+
+            encoded_result = b'\x00' + len(result_bytes).to_bytes(4, 'big') + result_bytes
+            await self.progress_queue.put(encoded_result)
+        except Exception as e:
+            err_bytes = str(e).encode("utf-8")
+            encoded_result = b'\x02' + len(err_bytes).to_bytes(4, 'big') + err_bytes
+            await self.progress_queue.put(encoded_result)
+        finally:
+            self.lock.release()
+
+
+    def check_nonce(self, request: Request):
+        if self.nonce:
+            nonce = request.headers.get('X-Nonce')
+            if nonce != self.nonce:
+                raise HTTPException(401, detail="Nonce does not match")
+
+    def check_lock(self):
+        if not self.lock.acquire(blocking=False):
+            raise HTTPException(status_code=429, detail="some Method is already being executed.")
+
+    def get_fn(self, method_name: str):
+        if method_name.startswith("__"):
+            raise HTTPException(status_code=403, detail="These functions are not allowed to be executed remotely")
+        method = getattr(self.manga, method_name, None)
+        if not method:
+            raise HTTPException(status_code=404, detail="Method not found")
+        return method
+
+    async def listen(self, translation_params: dict = None):
+        app = FastAPI()
+
+        @app.get("/is_locked")
+        async def is_locked():
+            if self.lock.locked():
+                return {"locked": True}
+            return {"locked": False}
+
+        @app.post("/simple_execute/{method_name}")
+        async def execute_method(request: Request, method_name: str = Path(...)):
+            self.check_nonce(request)
+            self.check_lock()
+            method = self.get_fn(method_name)
+            attr = pickle.loads(await request.body())
+            try:
+                if asyncio.iscoroutinefunction(method):
+                    result = await method(**attr)
+                else:
+                    result = method(**attr)
+                self.lock.release()
+                result_bytes = pickle.dumps(result)
+                return Response(content=result_bytes, media_type="application/octet-stream")
+            except Exception as e:
+                self.lock.release()
+                raise HTTPException(status_code=500, detail=str(e))
+
+        @app.post("/execute/{method_name}")
+        async def execute_method(request: Request, method_name: str = Path(...)):
+            self.check_nonce(request)
+            self.check_lock()
+            method = self.get_fn(method_name)
+            attr = pickle.loads(await request.body())
+
+            # 根据端点类型决定是否使用占位符优化
+            config = attr.get('config')
+            self.manga._is_streaming_mode = getattr(config, '_web_frontend_optimized', False) if config else False
+
+            # streaming response
+            streaming_response = StreamingResponse(self.progress_stream(), media_type="application/octet-stream")
+            asyncio.create_task(self.run_method(method, **attr))
+            return streaming_response
+
+        config = uvicorn.Config(app, host=self.host, port=self.port)
+        server = uvicorn.Server(config)
+        await server.serve()

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ aioshutil
 aiofiles
 arabic-reshaper
 pyhyphen
-langcodes
+langcodes[data]
 manga-ocr
 langdetect
 pydensecrf@https://github.com/lucasb-eyer/pydensecrf/archive/refs/heads/master.zip

--- a/server/args.py
+++ b/server/args.py
@@ -42,7 +42,7 @@ def parse_arguments():
     parser.add_argument('--start-instance', action='store_true',
                         help='If a translator should be launched automatically')
     parser.add_argument('--ignore-errors', action='store_true', help='Skip image on encountered error.')
-    parser.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE') or None, type=str, help='Nonce for securing internal web server communication')
+    parser.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE') or None, type=str, help='Nonce for securing internal web server communication, set to "None" to disable')
     parser.add_argument('--models-ttl', default='0', type=int, help='models TTL in memory in seconds')
     parser.add_argument('--pre-dict', default=None, type=file_path, help='Path to the pre-translation dictionary file')
     parser.add_argument('--post-dict', default=None, type=file_path, help='Path to the post-translation dictionary file')    

--- a/server/args.py
+++ b/server/args.py
@@ -42,7 +42,7 @@ def parse_arguments():
     parser.add_argument('--start-instance', action='store_true',
                         help='If a translator should be launched automatically')
     parser.add_argument('--ignore-errors', action='store_true', help='Skip image on encountered error.')
-    parser.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE', ''), type=str, help='Nonce for securing internal web server communication')
+    parser.add_argument('--nonce', default=os.getenv('MT_WEB_NONCE') or None, type=str, help='Nonce for securing internal web server communication')
     parser.add_argument('--models-ttl', default='0', type=int, help='models TTL in memory in seconds')
     parser.add_argument('--pre-dict', default=None, type=file_path, help='Path to the pre-translation dictionary file')
     parser.add_argument('--post-dict', default=None, type=file_path, help='Path to the post-translation dictionary file')    


### PR DESCRIPTION
Re-enabled the shared API mode functionality. Integrated the patch proposed by the CVE author to mitigate [CVE-2026-26215]
Closes #1116 
Changes:
1. Restores Shared API mode functionality.
2. Implements the security patch suggested by the CVE author.
3. Adds a configuration flag to explicitly disable nonce checks in shared mode.

The SAFE_PICKLE_MODULES list has been expanded based on local testing. However, it may require further additions depending on specific settings. Please report any unpickling errors.