### PR TITLE
fix: update Colab notebook with working server and CUDA fix

### DIFF
--- a/run_as_colab.ipynb
+++ b/run_as_colab.ipynb
@@ -4,7 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# For users who don't have a GPU!"
+    "# Manga Image Translator - Google Colab\n",
+    "\n",
+    "Translate manga/images into your desired language using AI.\n",
+    "\n",
+    "**\u26a0\ufe0f Make sure to select a GPU runtime before running:**\n",
+    "`Runtime` \u2192 `Change runtime type` \u2192 Select `T4 GPU` (or better)"
    ]
   },
   {
@@ -13,10 +18,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set up the environment.\n",
+    "# Clone the repository\n",
     "!git clone https://github.com/zyddnys/manga-image-translator\n",
-    "%cd manga-image-translator/\n",
-    "!python -m pip install -r requirements.txt\n"
+    "%cd /content/manga-image-translator/\n",
+    "\n",
+    "# Install all dependencies\n",
+    "!pip install -r requirements.txt\n",
+    "\n",
+    "# CRITICAL: Force-reinstall CUDA-enabled PyTorch\n",
+    "# Transitive dependencies (manga-ocr, open_clip_torch, kornia, timm, etc.) may have\n",
+    "# pulled in CPU-only torch, overwriting Colab's CUDA version.\n",
+    "# This reinstalls torch+torchvision with CUDA 12.4 support (matching Colab's toolkit).\n",
+    "# --no-deps prevents cascading dependency changes. --force-reinstall overwrites the CPU version.\n",
+    "!pip install torch torchvision --force-reinstall --no-deps --index-url https://download.pytorch.org/whl/cu124\n",
+    "\n",
+    "print('\\n\u2705 Installation complete!')"
    ]
   },
   {
@@ -25,11 +41,61 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run with colab. GPU must be selected at runtime!\n",
+    "# Verify CUDA is available (should print True)\n",
+    "import torch\n",
+    "print(f'PyTorch version: {torch.__version__}')\n",
+    "print(f'CUDA available: {torch.cuda.is_available()}')\n",
+    "if torch.cuda.is_available():\n",
+    "    print(f'GPU: {torch.cuda.get_device_name(0)}')\n",
+    "else:\n",
+    "    print('\\u274c CUDA not available! Make sure you selected a GPU runtime.')\n",
+    "    print('Go to: Runtime -> Change runtime type -> Select T4 GPU')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (Optional) Set translator API keys\n",
+    "\n",
+    "If you want to use cloud-based translators (e.g., GPT, DeepL, Gemini), set the corresponding\n",
+    "environment variables below. Skip this cell if you only need the default translator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment and fill in the API keys for the translators you want to use\n",
+    "import os\n",
+    "\n",
+    "# OpenAI / ChatGPT\n",
+    "# os.environ['OPENAI_API_KEY'] = 'your-key-here'\n",
+    "# os.environ['OPENAI_MODEL'] = 'gpt-4o-mini'\n",
+    "\n",
+    "# DeepL\n",
+    "# os.environ['DEEPL_AUTH_KEY'] = 'your-key-here'\n",
+    "\n",
+    "# Google Gemini\n",
+    "# os.environ['GOOGLE_GEMINI_API_KEY'] = 'your-key-here'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start the web server with Colab proxy\n",
     "from google.colab.output import eval_js\n",
-    "url = eval_js(\"google.colab.kernel.proxyPort(5003)\")\n",
-    "print('Open the link to use manga-image-translator! -> ', url)\n",
-    "!python -m manga_translator --verbose --mode web --use-gpu"
+    "\n",
+    "port = 8000\n",
+    "url = eval_js(f\"google.colab.kernel.proxyPort({port})\")\n",
+    "print(f'Open this link to use manga-image-translator \\u2192 {url}')\n",
+    "\n",
+    "!python server/main.py --host 0.0.0.0 --port {port} --use-gpu --verbose"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

The `run_as_colab.ipynb` notebook was outdated and completely non-functional:

- Used the removed `--mode web` CLI flag (replaced by `server/main.py` FastAPI server)
- Used wrong port 5003 (server now defaults to 8000)
- Filtering `torch`/`torchvision` from `requirements.txt` before `pip install` failed because transitive dependencies from packages like `manga-ocr`, `open_clip_torch`, `kornia`, `timm`, `accelerate`, `bitsandbytes`, etc. still pulled in CPU-only torch, causing the translator subprocess to crash with `CUDA or Metal compatible device could not be found`

## Changes

- **Updated server launch**: Use `python server/main.py --host 0.0.0.0 --port 8000 --use-gpu --verbose` instead of the removed `--mode web`
- **Fixed CUDA issue**: Install all requirements first, then force-reinstall CUDA-enabled PyTorch with `pip install torch torchvision --force-reinstall --no-deps --index-url https://download.pytorch.org/whl/cu124` to overwrite any CPU-only version pulled in by transitive dependencies
- **Added CUDA verification cell**: Verifies `torch.cuda.is_available()` and prints GPU name before starting the server
- **Added optional API keys cell**: Commented-out environment variables for OpenAI, DeepL, and Gemini translators
- **Improved documentation**: Better title, GPU runtime instructions, and inline comments explaining the CUDA fix

## Testing

Tested on Google Colab with T4 GPU runtime:
- ✅ All dependencies install successfully
- ✅ CUDA verification shows `True` with correct GPU name
- ✅ Server starts and translator subprocess runs on GPU
- ✅ Web UI accessible via Colab proxy URL

Closes #789
Closes #1130