### PR TITLE
Security: Insecure deserialization of untrusted network data using pickle

### DIFF
--- a/server/sent_data_internal.py
+++ b/server/sent_data_internal.py
@@ -1,3 +1,4 @@
+import json
 import pickle
 from typing import Mapping, Optional, Callable
 
@@ -27,7 +28,10 @@ async def fetch_data(url, image: Image, config: Config, headers: Mapping[str, st
     async with aiohttp.ClientSession() as session:
         async with session.post(url, data=data, headers=headers) as response:
             if response.status == 200:
-                return pickle.loads(await response.read())
+                try:
+                    return json.loads(await response.text())
+                except json.JSONDecodeError:
+                    raise HTTPException(502, detail='Invalid JSON response from upstream')
             else:
                 raise HTTPException(response.status, detail=await response.text())
 


### PR DESCRIPTION
## Problem

The server deserializes data from HTTP responses with `pickle.loads(await response.read())`. If the upstream endpoint is compromised or attacker-controlled, this enables arbitrary code execution during deserialization.

**Severity**: `critical`
**File**: `server/sent_data_internal.py`

## Solution

Do not use pickle for network payloads. Replace with a safe format (JSON/msgpack/protobuf) and strict schema validation. If binary transport is required, use signed payloads plus allowlisted types and never deserialize untrusted bytes directly.

## Changes

- `server/sent_data_internal.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
