### PR TITLE
fix: add unload() to CommonTranslator to prevent AttributeError with API translators

### DIFF
--- a/manga_translator/translators/common.py
+++ b/manga_translator/translators/common.py
@@ -120,6 +120,11 @@ class CommonTranslator(InfererModule):
         self.mtpe_adapter = MTPEAdapter()
         self._last_request_ts = 0
 
+
+    async def unload(self, device: str = None):
+        """No-op for API-based translators. Overridden by OfflineTranslator."""
+        pass
+
     def supports_languages(self, from_lang: str, to_lang: str, fatal: bool = False) -> bool:
         supported_src_languages = ['auto'] + list(self._LANGUAGE_CODE_MAP)
         supported_tgt_languages = list(self._LANGUAGE_CODE_MAP)


### PR DESCRIPTION
Fixes #1134

## Root cause

`dispatch()` in `manga_translator/translators/__init__.py` calls `await translator.unload(device)` on all translators. However, API-based translators (DeeplTranslator, BaiduTranslator, etc.) extend `CommonTranslator`, which has no `unload` method. Only `OfflineTranslator` (via `ModelWrapper`) defines it, so API translators raise `AttributeError`.

## Fix

Add a no-op `async def unload(self, device=None)` to `CommonTranslator` so all translators have the method. `OfflineTranslator` already overrides it with its own implementation, so existing behavior is unchanged.