### PR TITLE
fix: use restricted_loads in /execute endpoint to prevent RCE (CWE-502)

### DIFF
--- a/manga_translator/mode/share.py
+++ b/manga_translator/mode/share.py
@@ -140,10 +140,7 @@ class MangaShare:
             self.check_nonce(request)
             self.check_lock()
             method = self.get_fn(method_name)
-            if self.nonce is None:
-                 attr = pickle.loads(await request.body())
-            else:
-                attr = restricted_loads(await request.body())
+            attr = restricted_loads(await request.body())
             try:
                 if asyncio.iscoroutinefunction(method):
                     result = await method(**attr)
@@ -161,7 +158,7 @@ class MangaShare:
             self.check_nonce(request)
             self.check_lock()
             method = self.get_fn(method_name)
-            attr = pickle.loads(await request.body())
+            attr = restricted_loads(await request.body())
 
             # 根据端点类型决定是否使用占位符优化
             config = attr.get('config')


### PR DESCRIPTION
## Summary

The `/execute/{method_name}` endpoint in `manga_translator/mode/share.py` calls `pickle.loads()` directly on the HTTP request body without the module-allowlist protection that `restricted_loads()` already provides for `/simple_execute`.

Additionally, `/simple_execute` used raw `pickle.loads()` when `--nonce None` was passed (a documented deployment option), bypassing all authentication.

## Fix

Replace `pickle.loads(await request.body())` with `restricted_loads(await request.body())` in both endpoints. `restricted_loads` is already defined in this file and whitelists `builtins`, `collections`, `numpy`, `PIL`, and `manga_translator.*`.

## Impact

An attacker who can reach port 5003 can send a crafted pickle payload to execute arbitrary code as the server process. In the default Docker deployment the process runs as root.

- **`/execute`**: exploitable whenever the server is network-accessible and the nonce is known (sent as plaintext HTTP header)
- **`/simple_execute`**: exploitable with zero authentication when `--nonce None` is used

## Changes

`manga_translator/mode/share.py` — 3 lines changed:
- `/simple_execute`: remove the `if self.nonce is None` branch; always use `restricted_loads`
- `/execute`: replace `pickle.loads` with `restricted_loads`