### PR TITLE
Security: Unsafe Loading of PyTorch Models (Pickle RCE)

### DIFF
--- a/manga_translator/inpainting/ldm/modules/midas/midas/base_model.py
+++ b/manga_translator/inpainting/ldm/modules/midas/midas/base_model.py
@@ -8,7 +8,7 @@ class BaseModel(torch.nn.Module):
         Args:
             path (str): file path
         """
-        parameters = torch.load(path, map_location=torch.device('cpu'))
+        parameters = torch.load(path, map_location=torch.device('cpu'), weights_only=True)
 
         if "optimizer" in parameters:
             parameters = parameters["model"]


### PR DESCRIPTION
## Summary

Security: Unsafe Loading of PyTorch Models (Pickle RCE)

## Problem

**Severity**: `Medium` | **File**: `manga_translator/inpainting/ldm/modules/midas/midas/base_model.py:L10`

The `BaseModel.load` method in `manga_translator/inpainting/ldm/modules/midas/midas/base_model.py` uses `torch.load` without `weights_only=True`. Since `torch.load` uses pickle internally, loading a malicious model file can lead to arbitrary code execution. This risk exists wherever model weights are loaded from potentially untrusted sources (e.g., downloaded models).

## Solution

Set `weights_only=True` when calling `torch.load` (available in PyTorch 2.0+). If compatibility with older PyTorch versions is required, verify model integrity using cryptographic hashes and only load models from trusted sources.

## Changes

- `manga_translator/inpainting/ldm/modules/midas/midas/base_model.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"