### PR TITLE
feat(translators): add M2M100 HuggingFace translator (Nvidia CUDA / AMD ROCm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,8 @@ An example config file can be found in example/config-example.json
         "jparacrawl_big",
         "m2m100",
         "m2m100_big",
+        "m2m100_hf",
+        "m2m100_hf_big",
         "mbart50",
         "qwen2",
         "qwen2_big"
@@ -1125,8 +1127,10 @@ FIL: Filipino (Tagalog)
 | sugoi | | ✔️ | Sugoi V4.0 model |
 | jparacrawl | | ✔️ | Japanese translation model |
 | jparacrawl_big| | ✔️ | Larger Japanese translation model |
-| m2m100 | | ✔️ | Supports multilingual translation |
-| m2m100_big | | ✔️ | Larger M2M100 model |
+| m2m100 | | ✔️ | Supports multilingual translation (requires NVIDIA/ctranslate2) |
+| m2m100_big | | ✔️ | Larger M2M100 model (requires NVIDIA/ctranslate2) |
+| m2m100_hf | | ✔️ | M2M100 418M via HuggingFace — works on PyTorch (Nvidia CUDA / AMD ROCm) |
+| m2m100_hf_big | | ✔️ | M2M100 1.2B via HuggingFace — works on PyTorch (Nvidia CUDA / AMD ROCm) |
 | mbart50 | | ✔️ | Multilingual translation model |
 | qwen2 | | ✔️ | Qwen2 model |
 | qwen2_big | | ✔️ | Larger Qwen2 model |

--- a/manga_translator/config.py
+++ b/manga_translator/config.py
@@ -131,6 +131,8 @@ class Translator(str, Enum):
     jparacrawl_big = "jparacrawl_big"
     m2m100 = "m2m100"
     m2m100_big = "m2m100_big"
+    m2m100_hf = "m2m100_hf"
+    m2m100_hf_big = "m2m100_hf_big"
     mbart50 = "mbart50"
     qwen2 = "qwen2"
     qwen2_big = "qwen2_big"

--- a/manga_translator/translators/__init__.py
+++ b/manga_translator/translators/__init__.py
@@ -15,6 +15,7 @@ from .chatgpt_2stage import ChatGPT2StageTranslator
 from .nllb import NLLBTranslator, NLLBBigTranslator
 from .sugoi import JparacrawlTranslator, JparacrawlBigTranslator, SugoiTranslator
 from .m2m100 import M2M100Translator, M2M100BigTranslator
+from .m2m100_hf import M2M100HFTranslator, M2M100HFBigTranslator
 from .mbart50 import MBart50Translator
 from .selective import SelectiveOfflineTranslator, prepare as prepare_selective_translator
 from .none import NoneTranslator
@@ -37,6 +38,8 @@ OFFLINE_TRANSLATORS = {
     Translator.jparacrawl_big: JparacrawlBigTranslator,
     Translator.m2m100: M2M100Translator,
     Translator.m2m100_big: M2M100BigTranslator,
+    Translator.m2m100_hf: M2M100HFTranslator,
+    Translator.m2m100_hf_big: M2M100HFBigTranslator,
     Translator.mbart50: MBart50Translator,
     Translator.qwen2: Qwen2Translator,
     Translator.qwen2_big: Qwen2BigTranslator,

--- a/manga_translator/translators/m2m100_hf.py
+++ b/manga_translator/translators/m2m100_hf.py
@@ -1,0 +1,90 @@
+import os
+from typing import List
+from langdetect import detect
+
+from .common import OfflineTranslator
+
+ISO_639_1_TO_M2M100 = {
+    'zh': 'zh', 'cs': 'cs', 'nl': 'nl', 'en': 'en', 'fr': 'fr', 'de': 'de',
+    'hu': 'hu', 'it': 'it', 'ja': 'ja', 'ko': 'ko', 'pl': 'pl', 'pt': 'pt',
+    'ro': 'ro', 'ru': 'ru', 'es': 'es', 'tr': 'tr', 'uk': 'uk', 'vi': 'vi',
+    'ar': 'ar', 'sr': 'sr', 'hr': 'hr', 'th': 'th', 'id': 'id'
+}
+
+class M2M100HFTranslator(OfflineTranslator):
+    _LANGUAGE_CODE_MAP = {
+        'CHS': 'zh', 'CHT': 'zh', 'CSY': 'cs', 'NLD': 'nl', 'ENG': 'en',
+        'FRA': 'fr', 'DEU': 'de', 'HUN': 'hu', 'ITA': 'it', 'JPN': 'ja',
+        'KOR': 'ko', 'PLK': 'pl', 'PTB': 'pt', 'ROM': 'ro', 'RUS': 'ru',
+        'ESP': 'es', 'TRK': 'tr', 'UKR': 'uk', 'VIN': 'vi', 'ARA': 'ar',
+        'SRP': 'sr', 'HRV': 'hr', 'THA': 'th', 'IND': 'id'
+    }
+    _MODEL_SUB_DIR = os.path.join(OfflineTranslator._MODEL_DIR, OfflineTranslator._MODEL_SUB_DIR, 'm2m100')
+    _TRANSLATOR_MODEL = 'facebook/m2m100_418M'
+
+    async def _load(self, from_lang: str, to_lang: str, device: str):
+        from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+
+        if device not in ('cpu',) and ':' not in device:
+            device = device + ':0'
+        self.device = device
+        self.tokenizer = AutoTokenizer.from_pretrained(self._TRANSLATOR_MODEL)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(self._TRANSLATOR_MODEL)
+        self.model = self.model.to(device)
+        self.model.eval()
+
+    async def _unload(self):
+        del self.model
+        del self.tokenizer
+
+    async def _infer(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:
+        if from_lang == 'auto':
+            try:
+                detected = detect('\n'.join(queries))
+                from_lang = ISO_639_1_TO_M2M100.get(detected)
+            except Exception as e:
+                self.logger.warning(f'Language detection failed: {e}')
+                from_lang = None
+
+            if from_lang is None:
+                self.logger.warning('Could not detect source language, skipping translation')
+                return [''] * len(queries)
+
+        return self._translate_batch(from_lang, to_lang, queries)
+
+    def _translate_batch(self, from_lang: str, to_lang: str, queries: List[str]) -> List[str]:
+        import torch
+        try:
+            self.tokenizer.src_lang = from_lang
+            encoded = self.tokenizer(queries, return_tensors='pt', padding=True, truncation=True, max_length=512)
+            encoded = {k: v.to(self.device) for k, v in encoded.items()}
+            with torch.no_grad():
+                generated = self.model.generate(
+                    **encoded,
+                    forced_bos_token_id=self.tokenizer.get_lang_id(to_lang),
+                    max_length=512,
+                    num_beams=5,
+                )
+            return self.tokenizer.batch_decode(generated, skip_special_tokens=True)
+        except Exception as e:
+            self.logger.error(f'Batch translation failed: {e}')
+            return [''] * len(queries)
+
+    async def _download(self):
+        import huggingface_hub
+        huggingface_hub.snapshot_download(
+            self._TRANSLATOR_MODEL,
+            cache_dir=self._MODEL_SUB_DIR,
+            ignore_patterns=['*.msgpack', '*.h5', '*.ot', '.*'],
+        )
+
+    def _check_downloaded(self) -> bool:
+        import huggingface_hub
+        return (
+            huggingface_hub.try_to_load_from_cache(self._TRANSLATOR_MODEL, 'model.safetensors', cache_dir=self._MODEL_SUB_DIR) is not None
+            or huggingface_hub.try_to_load_from_cache(self._TRANSLATOR_MODEL, 'pytorch_model.bin', cache_dir=self._MODEL_SUB_DIR) is not None
+        )
+
+class M2M100HFBigTranslator(M2M100HFTranslator):
+    _MODEL_SUB_DIR = os.path.join(OfflineTranslator._MODEL_DIR, OfflineTranslator._MODEL_SUB_DIR, 'm2m100')
+    _TRANSLATOR_MODEL = 'facebook/m2m100_1.2B'

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,0 +1,21 @@
+# For AMD GPU (ROCm) support.
+# Install with:
+#   pip install -r requirements-rocm.txt
+#   pip uninstall onnxruntime -y && pip install onnxruntime-rocm
+#
+# Requires ROCm drivers: https://rocm.docs.amd.com/en/latest/deploy/linux/index.html
+# Supported GPUs: RX 6000/7000/9000 series, Instinct MI series
+
+--extra-index-url https://download.pytorch.org/whl/rocm6.4
+-r requirements.txt
+
+# ROCm builds of PyTorch (override CPU/CUDA versions from requirements.txt)
+torch
+torchvision
+
+# Note: onnxruntime from requirements.txt does not support ROCm.
+# After installing, replace it manually:
+#   pip uninstall onnxruntime -y && pip install onnxruntime-rocm
+
+# Note: ctranslate2 does not support ROCm.
+# Use m2m100_hf / nllb instead of m2m100 / nllb for offline translation on ROCm.


### PR DESCRIPTION
## Summary

Adds two new offline translator variants that use the HuggingFace `transformers`
library directly instead of `ctranslate2`.

| Key | Model | Backend |
|-----|-------|---------|
| `m2m100_hf` | facebook/m2m100_418M | HuggingFace / PyTorch |
| `m2m100_hf_big` | facebook/m2m100_1.2B | HuggingFace / PyTorch |

## Motivation

The existing `m2m100` and `m2m100_big` translators depend on `ctranslate2`, which
only supports Nvidia CUDA. Users with AMD GPUs (ROCm) have no working M2M100
option. These new variants run on any PyTorch-supported device (Nvidia CUDA,
AMD ROCm, CPU).

## Changes

- `manga_translator/translators/m2m100_hf.py` — new translator using
  `AutoModelForSeq2SeqLM` + `AutoTokenizer` directly (no pipeline-per-sentence)
- `manga_translator/config.py` — add `m2m100_hf` / `m2m100_hf_big` to `Translator` enum
- `manga_translator/translators/__init__.py` — register `m2m100_hf` / `m2m100_hf_big`
  in `OFFLINE_TRANSLATORS`
- `README.md` — add entries to translator reference table and JSON schema enum

## Notes

- Auto language detection via `langdetect` on the full batch
- Falls back to `''` on unrecoverable errors (no blocking `input()`)
- `_check_downloaded` checks both `model.safetensors` and `pytorch_model.bin`

Co-authored-by: GitHub Copilot <github-copilot[bot]@users.noreply.github.com>