### PR TITLE
fix: use working star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1492,4 +1492,4 @@ GPU server costs are high, please consider supporting us. Thank you very much!
 
 ## Star Growth Curve
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zyddnys/manga-image-translator&type=Date)](https://star-history.com/#zyddnys/manga-image-translator&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zyddnys/manga-image-translator&type=Date)](https://star-history.dera.page/#zyddnys/manga-image-translator&Date)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1480,4 +1480,4 @@ GPU 服务器开销较大，请考虑支持我们，非常感谢！
 
 ## Star 增长曲线
 
-[![Star History Chart](https://api.star-history.com/svg?repos=zyddnys/manga-image-translator&type=Date)](https://star-history.com/#zyddnys/manga-image-translator&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=zyddnys/manga-image-translator&type=Date)](https://star-history.dera.page/#zyddnys/manga-image-translator&Date)


### PR DESCRIPTION
The star history chart currently shown in the README is broken because of GitHub stargazer API restrictions. This change updates both the English and Chinese READMEs to use a working star history chart, so the repository's growth curve displays correctly again.